### PR TITLE
Change pop and parent to behave like std Path (fixes #11)

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,5 @@
 language: rust
 rust:
-  - nightly
   - beta
   - stable
 sudo: false


### PR DESCRIPTION
@matklad After working around a bit with the implementation. Behaving like `std::path::Path`, mimicking its behavior is the path of least resistance (no pun intended). The other ones I tried had weird trade-offs or awkward implementations, and if we're gonna have edge cases it's probably better to be aligned with `std`.

What do you think?