### PR TITLE
Add a kind() method to FromPathError

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -294,6 +294,13 @@ pub struct FromPathError {
     kind: FromPathErrorKind,
 }
 
+impl FromPathError {
+    /// Gets `FromPathErrorKind` that provides more details on what went wrong
+    pub fn kind(&self) -> FromPathErrorKind {
+        self.kind
+    }
+}
+
 impl From<FromPathErrorKind> for FromPathError {
     fn from(value: FromPathErrorKind) -> Self {
         Self { kind: value }


### PR DESCRIPTION
There is no localizable way of telling user what when wrong when creating a relative path via `from_path()` method.
This patch adds a new method makes it possible to get exact error kind and then display a localized error message to user.