### PR TITLE
Change to_path to not use push-like behavior for absolute components

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -7,12 +7,13 @@ jobs:
     strategy:
       matrix:
         toolchain: [stable, beta]
+        os: [ubuntu-latest, windows-latest, macos-latest]
         experimental: [false]
         include:
           - toolchain: nightly
             experimental: true
+    runs-on: ${{ matrix.os }}
     continue-on-error: ${{ matrix.experimental }}
-    runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v1
     - uses: actions-rs/toolchain@v1

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+* Changed `to_path` to ignore platform-specific absolute components ([#18]).
+
+[#18]: https://github.com/udoprog/relative-path/pull/18
+
 ## [1.2.1] - 2020-06-16
 
 ### Changed


### PR DESCRIPTION
While this is strictly speaking a change in behavior. Prior to this change, a relative path like `"c:\\path\\to\\source"` when converted into an actual path on Windows would ignore the `relative_to` argument which contradicts the promise of relative paths. Therefore this is instead a bugfix and a minor change since it fixes the relative path to behave as promised and only generate paths relative to the specified path during conversion.

The path generated will most likely be nonsensical for the platform it is generated for, but this is intended since it means the user has provided the library with a non-relative path and it should break as early as possible.