### PR TITLE
Implement Extend and FromIterator for RelativePathBuf

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -196,6 +196,7 @@ use std::cmp;
 use std::error;
 use std::fmt;
 use std::hash::{Hash, Hasher};
+use std::iter::FromIterator;
 use std::mem;
 use std::ops::{self, Deref};
 use std::path;
@@ -780,6 +781,20 @@ impl cmp::Ord for RelativePathBuf {
 impl Hash for RelativePathBuf {
     fn hash<H: Hasher>(&self, h: &mut H) {
         self.as_relative_path().hash(h)
+    }
+}
+
+impl<P: AsRef<RelativePath>> Extend<P> for RelativePathBuf {
+    fn extend<I: IntoIterator<Item = P>>(&mut self, iter: I) {
+        iter.into_iter().for_each(move |p| self.push(p.as_ref()));
+    }
+}
+
+impl<P: AsRef<RelativePath>> FromIterator<P> for RelativePathBuf {
+    fn from_iter<I: IntoIterator<Item = P>>(iter: I) -> RelativePathBuf {
+        let mut buf = RelativePathBuf::new();
+        buf.extend(iter);
+        buf
     }
 }
 


### PR DESCRIPTION
Implementations match those in `std::path::PathBuf`:
https://github.com/rust-lang/rust/blob/3a24abd22fd25c836d8b4d75ff46c833f9c3934c/library/std/src/path.rs#L1533
https://github.com/rust-lang/rust/blob/3a24abd22fd25c836d8b4d75ff46c833f9c3934c/library/std/src/path.rs#L1542