### PR TITLE
Treat empty paths correctly

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "relative-path"
-version = "1.5.0"
+version = "1.5.1"
 authors = ["John-John Tedro <udoprog@tedro.se>"]
 license = "MIT/Apache-2.0"
 repository = "https://github.com/udoprog/relative-path"

--- a/README.md
+++ b/README.md
@@ -7,27 +7,35 @@
 
 Portable relative UTF-8 paths for Rust.
 
-This provide a module analogous to [std::path], with the following characteristics:
+This provide a module analogous to [std::path], with the following
+characteristics:
 
-* The path separator is set to a fixed character (`/`), regardless of platform.
-* Relative paths cannot represent a path in the filesystem without first specifying what they
-  are *relative to* through [to_path].
+* The path separator is set to a fixed character (`/`), regardless of
+  platform.
+* Relative paths cannot represent a path in the filesystem without first
+  specifying what they are *relative to* through [to_path].
 * Relative paths are always guaranteed to be a UTF-8 string.
 
-On top of this we support many path-like operations that guarantee portable behavior.
+On top of this we support many path-like operations that guarantee portable
+behavior.
 
 ### Serde Support
 
-This library includes serde support that can be enabled with the `serde` feature.
+This library includes serde support that can be enabled with the `serde`
+feature.
 
 ### Why is `std::path` a portability hazard?
 
 Path representations differ across platforms.
 
-* Windows permits using drive volumes (multiple roots) as a prefix (e.g. `"c:\"`) and backslash (`\`) as a separator.
-* Unix references absolute paths from a single root and uses slash (`/`) as a separator.
+* Windows permits using drive volumes (multiple roots) as a prefix (e.g.
+  `"c:\"`) and backslash (`\`) as a separator.
+* Unix references absolute paths from a single root and uses slash (`/`) as
+  a separator.
 
-If we use `PathBuf`, Storing paths like this in a manifest would happily allow our applications to build and run on one platform, but potentially not others.
+If we use `PathBuf`, Storing paths like this in a manifest would happily
+allow our applications to build and run on one platform, but potentially not
+others.
 
 Consider the following manifest:
 
@@ -75,8 +83,9 @@ let full_path = relative_path.to_logical_path("C:\\baz");
 assert_eq!(full_path, Path::new("C:\\foo\\bar"));
 ```
 
-This would permit relative paths to portably be used in project manifests or configurations.
-Where files are referenced from some specific, well-known point in the filesystem.
+This would permit relative paths to portably be used in project manifests or
+configurations. Where files are referenced from some specific, well-known
+point in the filesystem.
 
 ```toml
 source = "path/to/source"
@@ -96,7 +105,8 @@ pub struct Manifest {
 
 ### Overview
 
-When two relative paths are compared to each other, their exact component makeup determines equality.
+When two relative paths are compared to each other, their exact component
+makeup determines equality.
 
 ```rust
 use relative_path::RelativePath;
@@ -107,9 +117,11 @@ assert_ne!(
 );
 ```
 
-Using platform-specific path separators to construct relative paths is not supported.
+Using platform-specific path separators to construct relative paths is not
+supported.
 
-Path separators from other platforms are simply treated as part of a component:
+Path separators from other platforms are simply treated as part of a
+component:
 
 ```rust
 use relative_path::RelativePath;
@@ -136,21 +148,23 @@ assert_eq!(
 
 ### Additional portability notes
 
-While relative paths avoid the most egregious portability issues, namely that absolute paths will work equally unwell on all platforms.
-We do not avoid all.
+While relative paths avoid the most egregious portability issues, namely
+that absolute paths will work equally unwell on all platforms. We do not
+avoid all.
 
 This section tries to document additional portability issues that we know
 about.
 
-[RelativePath], similarly to [Path], makes no guarantees that the components represented in them
-makes up legal file names.
-While components are strictly separated by slashes, we can still store things in path components which may not be used as legal paths on all platforms.
+[RelativePath], similarly to [Path], makes no guarantees that the components
+represented in them makes up legal file names. While components are strictly
+separated by slashes, we can still store things in path components which may
+not be used as legal paths on all platforms.
 
-* `NUL` is not permitted on unix platforms - this is a terminator in C-based filesystem APIs. Slash
-(`/`) is also used as a path separator.
+* `NUL` is not permitted on unix platforms - this is a terminator in C-based
+  filesystem APIs. Slash (`/`) is also used as a path separator.
 * Windows has a number of [reserved characters and names][windows-reserved].
 
-As a relative path that *actually* contains a platform-specific absolute path
+A relative path that *actually* contains a platform-specific absolute path
 will result in a nonsensical path being generated.
 
 ```rust
@@ -174,11 +188,10 @@ if cfg!(unix) {
 
 This is intentional in order to cause an early breakage when a platform
 encounters paths like `"foo/c:\\bar\\baz"` to signal that it is a
-portability hazard.
-On Unix it's a bit more subtle with `""foo/bar/baz""`, since the leading
-slash (`/`) will simply be ignored.
-The hope is that it will be more probable to cause an early error unless a
-compatible relative path *also* exists.
+portability hazard. On Unix it's a bit more subtle with `""foo/bar/baz""`,
+since the leading slash (`/`) will simply be ignored. The hope is that it
+will be more probable to cause an early error unless a compatible relative
+path *also* exists.
 
 [windows-reserved]: https://msdn.microsoft.com/en-us/library/windows/desktop/aa365247(v=vs.85).aspx
 [RelativePath]: https://docs.rs/relative-path/1/relative_path/struct.RelativePath.html

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,26 +1,34 @@
 //! Portable relative UTF-8 paths for Rust.
 //!
-//! This provide a module analogous to [std::path], with the following characteristics:
+//! This provide a module analogous to [std::path], with the following
+//! characteristics:
 //!
-//! * The path separator is set to a fixed character (`/`), regardless of platform.
-//! * Relative paths cannot represent a path in the filesystem without first specifying what they
-//!   are *relative to* through [to_path].
+//! * The path separator is set to a fixed character (`/`), regardless of
+//!   platform.
+//! * Relative paths cannot represent a path in the filesystem without first
+//!   specifying what they are *relative to* through [to_path].
 //! * Relative paths are always guaranteed to be a UTF-8 string.
 //!
-//! On top of this we support many path-like operations that guarantee portable behavior.
+//! On top of this we support many path-like operations that guarantee portable
+//! behavior.
 //!
 //! ## Serde Support
 //!
-//! This library includes serde support that can be enabled with the `serde` feature.
+//! This library includes serde support that can be enabled with the `serde`
+//! feature.
 //!
 //! ## Why is `std::path` a portability hazard?
 //!
 //! Path representations differ across platforms.
 //!
-//! * Windows permits using drive volumes (multiple roots) as a prefix (e.g. `"c:\"`) and backslash (`\`) as a separator.
-//! * Unix references absolute paths from a single root and uses slash (`/`) as a separator.
+//! * Windows permits using drive volumes (multiple roots) as a prefix (e.g.
+//!   `"c:\"`) and backslash (`\`) as a separator.
+//! * Unix references absolute paths from a single root and uses slash (`/`) as
+//!   a separator.
 //!
-//! If we use `PathBuf`, Storing paths like this in a manifest would happily allow our applications to build and run on one platform, but potentially not others.
+//! If we use `PathBuf`, Storing paths like this in a manifest would happily
+//! allow our applications to build and run on one platform, but potentially not
+//! others.
 //!
 //! Consider the following manifest:
 //!
@@ -70,8 +78,9 @@
 //! # }
 //! ```
 //!
-//! This would permit relative paths to portably be used in project manifests or configurations.
-//! Where files are referenced from some specific, well-known point in the filesystem.
+//! This would permit relative paths to portably be used in project manifests or
+//! configurations. Where files are referenced from some specific, well-known
+//! point in the filesystem.
 //!
 //! ```toml
 //! source = "path/to/source"
@@ -91,7 +100,8 @@
 //!
 //! ## Overview
 //!
-//! When two relative paths are compared to each other, their exact component makeup determines equality.
+//! When two relative paths are compared to each other, their exact component
+//! makeup determines equality.
 //!
 //! ```rust
 //! use relative_path::RelativePath;
@@ -102,9 +112,11 @@
 //! );
 //! ```
 //!
-//! Using platform-specific path separators to construct relative paths is not supported.
+//! Using platform-specific path separators to construct relative paths is not
+//! supported.
 //!
-//! Path separators from other platforms are simply treated as part of a component:
+//! Path separators from other platforms are simply treated as part of a
+//! component:
 //!
 //! ```rust
 //! use relative_path::RelativePath;
@@ -131,21 +143,23 @@
 //!
 //! ## Additional portability notes
 //!
-//! While relative paths avoid the most egregious portability issues, namely that absolute paths will work equally unwell on all platforms.
-//! We do not avoid all.
+//! While relative paths avoid the most egregious portability issues, namely
+//! that absolute paths will work equally unwell on all platforms. We do not
+//! avoid all.
 //!
 //! This section tries to document additional portability issues that we know
 //! about.
 //!
-//! [RelativePath], similarly to [Path], makes no guarantees that the components represented in them
-//! makes up legal file names.
-//! While components are strictly separated by slashes, we can still store things in path components which may not be used as legal paths on all platforms.
+//! [RelativePath], similarly to [Path], makes no guarantees that the components
+//! represented in them makes up legal file names. While components are strictly
+//! separated by slashes, we can still store things in path components which may
+//! not be used as legal paths on all platforms.
 //!
-//! * `NUL` is not permitted on unix platforms - this is a terminator in C-based filesystem APIs. Slash
-//! (`/`) is also used as a path separator.
+//! * `NUL` is not permitted on unix platforms - this is a terminator in C-based
+//!   filesystem APIs. Slash (`/`) is also used as a path separator.
 //! * Windows has a number of [reserved characters and names][windows-reserved].
 //!
-//! As a relative path that *actually* contains a platform-specific absolute path
+//! A relative path that *actually* contains a platform-specific absolute path
 //! will result in a nonsensical path being generated.
 //!
 //! ```rust
@@ -169,11 +183,10 @@
 //!
 //! This is intentional in order to cause an early breakage when a platform
 //! encounters paths like `"foo/c:\\bar\\baz"` to signal that it is a
-//! portability hazard.
-//! On Unix it's a bit more subtle with `""foo/bar/baz""`, since the leading
-//! slash (`/`) will simply be ignored.
-//! The hope is that it will be more probable to cause an early error unless a
-//! compatible relative path *also* exists.
+//! portability hazard. On Unix it's a bit more subtle with `""foo/bar/baz""`,
+//! since the leading slash (`/`) will simply be ignored. The hope is that it
+//! will be more probable to cause an early error unless a compatible relative
+//! path *also* exists.
 //!
 //! [windows-reserved]: https://msdn.microsoft.com/en-us/library/windows/desktop/aa365247(v=vs.85).aspx
 //! [RelativePath]: https://docs.rs/relative-path/1/relative_path/struct.RelativePath.html


### PR DESCRIPTION
The way that `to_path` and `to_logical_path` reacts to *empty* paths wasn't properly specified nor implemented. The current behavior ends up being rather on, in that the main separator is added so that the following would produce an absolute path on Linux:

```rust
let path = RelativePath::new("foo/bar").to_path("");
assert_eq!(Path::new("/foo/bar"), path);
```

This is clearly dysfunctional and contrary to what this crate is trying to accomplish. So this patch changes this behavior so that we only add the main separator for cases where the `from` path is non-empty.

What we then get instead is:

```rust
let path = RelativePath::new("foo/bar").to_path("");
assert_eq!(Path::new("foo/bar"), path);
```