### PR TITLE
Support common prefixes in RelativePath::relative (fixes #30)

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -478,7 +478,7 @@ impl FromPathError {
     ///
     /// # Examples
     ///
-    /// ```rust
+    /// ```
     /// use std::path::Path;
     /// use relative_path::{FromPathErrorKind, RelativePathBuf};
     ///
@@ -541,7 +541,7 @@ impl RelativePathBuf {
     ///
     /// # Examples
     ///
-    /// ```rust
+    /// ```
     /// use relative_path::{RelativePath, RelativePathBuf, FromPathErrorKind};
     /// use std::path::Path;
     ///
@@ -573,7 +573,7 @@ impl RelativePathBuf {
     ///
     /// # Examples
     ///
-    /// ```rust
+    /// ```
     /// use relative_path::{RelativePathBuf, RelativePath};
     ///
     /// let mut path = RelativePathBuf::new();
@@ -853,7 +853,7 @@ impl RelativePath {
     ///
     /// # Examples
     ///
-    /// ```rust
+    /// ```
     /// use relative_path::{RelativePath, FromPathErrorKind};
     ///
     /// assert_eq!(
@@ -935,7 +935,7 @@ impl RelativePath {
     ///
     /// # Examples
     ///
-    /// ```rust
+    /// ```
     /// use relative_path::RelativePath;
     ///
     /// let path = RelativePath::new("foo/bar");
@@ -951,7 +951,7 @@ impl RelativePath {
     ///
     /// # Examples
     ///
-    /// ```rust
+    /// ```
     /// use relative_path::{Component, RelativePath};
     ///
     /// let path = RelativePath::new("foo/bar/baz");
@@ -1000,7 +1000,7 @@ impl RelativePath {
     ///
     /// # Examples
     ///
-    /// ```rust
+    /// ```
     /// use relative_path::RelativePath;
     /// use std::path::Path;
     ///
@@ -1019,7 +1019,7 @@ impl RelativePath {
     /// This is to preserve the probability of a path conversion failing if the
     /// relative path contains platform-specific absolute path components.
     ///
-    /// ```rust
+    /// ```
     /// use relative_path::RelativePath;
     /// use std::path::Path;
     ///
@@ -1073,7 +1073,7 @@ impl RelativePath {
     /// corresponding [PathBuf] operation. E.g. popping a component off a path
     /// like `.` will result in an empty path.
     ///
-    /// ```rust
+    /// ```
     /// use relative_path::RelativePath;
     /// use std::path::Path;
     ///
@@ -1083,7 +1083,7 @@ impl RelativePath {
     ///
     /// # Examples
     ///
-    /// ```rust
+    /// ```
     /// use relative_path::RelativePath;
     /// use std::path::Path;
     ///
@@ -1102,7 +1102,7 @@ impl RelativePath {
     /// This is to preserve the probability of a path conversion failing if the
     /// relative path contains platform-specific absolute path components.
     ///
-    /// ```rust
+    /// ```
     /// use relative_path::RelativePath;
     /// use std::path::Path;
     ///
@@ -1161,7 +1161,7 @@ impl RelativePath {
     ///
     /// # Examples
     ///
-    /// ```rust
+    /// ```
     /// use relative_path::RelativePath;
     ///
     /// assert_eq!(Some(RelativePath::new("foo")), RelativePath::new("foo/bar").parent());
@@ -1416,7 +1416,7 @@ impl RelativePath {
     ///
     /// # Examples
     ///
-    /// ```rust
+    /// ```
     /// use relative_path::RelativePath;
     ///
     /// assert_eq!(
@@ -1451,7 +1451,7 @@ impl RelativePath {
     ///
     /// # Examples
     ///
-    /// ```rust
+    /// ```
     /// use relative_path::RelativePath;
     ///
     /// assert_eq!(
@@ -1493,7 +1493,7 @@ impl RelativePath {
     /// which point there's no need to know what the names of those unnamed
     /// components are.
     ///
-    /// ```rust
+    /// ```
     /// use relative_path::RelativePath;
     ///
     /// let source = RelativePath::new("../../foo/bar");
@@ -1509,7 +1509,7 @@ impl RelativePath {
     ///
     /// # Examples
     ///
-    /// ```rust
+    /// ```
     /// use relative_path::RelativePath;
     ///
     /// assert_eq!(

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1472,38 +1472,39 @@ impl RelativePath {
 
     /// Constructs a relative path from the current path, to `path`.
     ///
-    /// This function will return the empty relative path `""` if the component
-    /// we are traversing *from* contains unnamed components like `..` that
-    /// would have to be traversed to reach the destination. This is necessary,
-    /// since we have no idea what the names of those components are when we're
-    /// building the new relative path.
+    /// This function will return the empty [RelativePath] `""` if this source
+    /// contains unnamed components like `..` that would have to be traversed to
+    /// reach the destination. This is necessary since we have no way of knowing
+    /// what the names of those components are when we're building the new
+    /// relative path.
     ///
     /// ```
     /// use relative_path::RelativePath;
     ///
-    /// // Here we don't know what directories `../..` refer to, so there's no
-    /// // way to construct a path back to `bar` from `../..`.
-    /// let r = RelativePath::new("../../foo/relative-path");
-    /// let p = RelativePath::new("bar");
-    /// assert_eq!("", r.relative(p));
+    /// // Here we don't know what directories `../..` refers to, so there's no
+    /// // way to construct a path back to `bar` in the current directory from
+    /// // `../..`.
+    /// let source = RelativePath::new("../../foo/relative-path");
+    /// let destination = RelativePath::new("bar");
+    /// assert_eq!("", source.relative(destination));
     /// ```
     ///
-    /// One exception to this is when two paths contains a common prefix, at
+    /// One exception to this is when two paths contains a common prefix at
     /// which point there's no need to know what the names of those unnamed
     /// components are.
     ///
     /// ```rust
     /// use relative_path::RelativePath;
     ///
-    /// let a = RelativePath::new("../../foo/bar");
-    /// let b = RelativePath::new("../../foo/baz");
+    /// let source = RelativePath::new("../../foo/bar");
+    /// let destination = RelativePath::new("../../foo/baz");
     ///
-    /// assert_eq!("../baz", a.relative(b));
+    /// assert_eq!("../baz", source.relative(destination));
     ///
-    /// let a = RelativePath::new("../a/../../foo/bar");
-    /// let b = RelativePath::new("../../foo/baz");
+    /// let source = RelativePath::new("../a/../../foo/bar");
+    /// let destination = RelativePath::new("../../foo/baz");
     ///
-    /// assert_eq!("../baz", a.relative(b));
+    /// assert_eq!("../baz", source.relative(destination));
     /// ```
     ///
     /// # Examples
@@ -1521,10 +1522,10 @@ impl RelativePath {
     ///     RelativePath::new("a/../aaa").relative(RelativePath::new("b/../bbb"))
     /// );
     ///
-    /// let p = RelativePath::new("git/relative-path");
-    /// let r = RelativePath::new("git");
-    /// assert_eq!("relative-path", r.relative(p));
-    /// assert_eq!("..", p.relative(r));
+    /// let a = RelativePath::new("git/relative-path");
+    /// let b = RelativePath::new("git");
+    /// assert_eq!("relative-path", b.relative(a));
+    /// assert_eq!("..", a.relative(b));
     ///
     /// let a = RelativePath::new("foo/bar/bap/foo.h");
     /// let b = RelativePath::new("../arch/foo.h");

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1474,9 +1474,9 @@ impl RelativePath {
     ///
     /// This function will return the empty [RelativePath] `""` if this source
     /// contains unnamed components like `..` that would have to be traversed to
-    /// reach the destination. This is necessary since we have no way of knowing
-    /// what the names of those components are when we're building the new
-    /// relative path.
+    /// reach the destination `path`. This is necessary since we have no way of
+    /// knowing what the names of those components are when we're building the
+    /// new relative path.
     ///
     /// ```
     /// use relative_path::RelativePath;
@@ -1484,9 +1484,9 @@ impl RelativePath {
     /// // Here we don't know what directories `../..` refers to, so there's no
     /// // way to construct a path back to `bar` in the current directory from
     /// // `../..`.
-    /// let source = RelativePath::new("../../foo/relative-path");
-    /// let destination = RelativePath::new("bar");
-    /// assert_eq!("", source.relative(destination));
+    /// let from = RelativePath::new("../../foo/relative-path");
+    /// let to = RelativePath::new("bar");
+    /// assert_eq!("", from.relative(to));
     /// ```
     ///
     /// One exception to this is when two paths contains a common prefix at
@@ -1496,15 +1496,15 @@ impl RelativePath {
     /// ```
     /// use relative_path::RelativePath;
     ///
-    /// let source = RelativePath::new("../../foo/bar");
-    /// let destination = RelativePath::new("../../foo/baz");
+    /// let from = RelativePath::new("../../foo/bar");
+    /// let to = RelativePath::new("../../foo/baz");
     ///
-    /// assert_eq!("../baz", source.relative(destination));
+    /// assert_eq!("../baz", from.relative(to));
     ///
-    /// let source = RelativePath::new("../a/../../foo/bar");
-    /// let destination = RelativePath::new("../../foo/baz");
+    /// let from = RelativePath::new("../a/../../foo/bar");
+    /// let to = RelativePath::new("../../foo/baz");
     ///
-    /// assert_eq!("../baz", source.relative(destination));
+    /// assert_eq!("../baz", from.relative(to));
     /// ```
     ///
     /// # Examples


### PR DESCRIPTION
This ensures that relative paths with a common prefix works with `RelativePath::relative`, simply by stripping common prefixes before the new path is calculated.

@Gordon01 This should fix your issue. All though note that there's nothing we can do about paths with unnamed components in *general*, because we don't know what those unknown components are. Some documentation was added to `RelativePath::relative` to explain this and I'd appreciate a review from you.