### PR TITLE
impl AsRef<str> for RelativePath

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -828,6 +828,12 @@ impl AsRef<RelativePath> for RelativePathBuf {
     }
 }
 
+impl AsRef<str> for RelativePath {
+    fn as_ref(&self) -> &str {
+        &self.inner
+    }
+}
+
 impl Borrow<RelativePath> for RelativePathBuf {
     fn borrow(&self) -> &RelativePath {
         self.deref()

--- a/src/tests.rs
+++ b/src/tests.rs
@@ -625,6 +625,11 @@ fn test_from() {
         RelativePathBuf::from(String::from("foo/bar")),
     );
 
+    assert_eq!(
+        RelativePathBuf::from(rp("foo/bar")),
+        RelativePathBuf::from("foo/bar"),
+    );
+
     assert_eq!(rp("foo/bar").to_owned(), RelativePathBuf::from("foo/bar"),);
 
     assert_eq!(&*Box::<RelativePath>::from(rp("foo/bar")), rp("foo/bar"));
@@ -644,6 +649,11 @@ fn test_from() {
         &*Rc::<RelativePath>::from(RelativePathBuf::from("foo/bar")),
         rp("foo/bar")
     );
+}
+
+#[test]
+fn test_relative_path_asref_str() {
+    assert_eq!(<RelativePath as AsRef<str>>::as_ref(rp("foo/bar")), "foo/bar");
 }
 
 #[test]


### PR DESCRIPTION
This has the side-effect of making `RelativePathBuf::from(relative_path)` work, so this closes #39.