### PR TITLE
widows folder separator in lib.rs

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -296,11 +296,10 @@ const STEM_SEP: char = '.';
 const CURRENT_STR: &str = ".";
 const PARENT_STR: &str = "..";
 
-if cfg!(target_os = "windows") {
+#[cfg(target_os = "windows")]
     const SEP: char = "\\";
-} else {
+#[cfg(not(target_os = "windows"))]
     const SEP: char = '/';
-}
 
 fn split_file_at_dot(input: &str) -> (Option<&str>, Option<&str>) {
     if input == PARENT_STR {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -296,7 +296,11 @@ const STEM_SEP: char = '.';
 const CURRENT_STR: &str = ".";
 const PARENT_STR: &str = "..";
 
-const SEP: char = '/';
+if cfg!(target_os = "windows") {
+    const SEP: char = "\\";
+} else {
+    const SEP: char = '/';
+}
 
 fn split_file_at_dot(input: &str) -> (Option<&str>, Option<&str>) {
     if input == PARENT_STR {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -297,7 +297,7 @@ const CURRENT_STR: &str = ".";
 const PARENT_STR: &str = "..";
 
 #[cfg(target_os = "windows")]
-    const SEP: char = '\';
+    const SEP: char = '\\';
 #[cfg(not(target_os = "windows"))]
     const SEP: char = '/';
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -297,7 +297,7 @@ const CURRENT_STR: &str = ".";
 const PARENT_STR: &str = "..";
 
 #[cfg(target_os = "windows")]
-    const SEP: char = "\\";
+    const SEP: char = '\';
 #[cfg(not(target_os = "windows"))]
     const SEP: char = '/';
 


### PR DESCRIPTION
shouldn't we be using backslash separator for windows platforms ?

otherwise, some path coming from this platform could be mixed with slashes, which would cause errors.