### PR TITLE
Start working on open_at support

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -17,7 +17,7 @@ jobs:
       fail-fast: false
       matrix:
         os: [ubuntu-latest, windows-latest, macos-latest]
-        toolchain: ["1.56", stable]
+        toolchain: ["1.63", stable]
     steps:
     - uses: actions/checkout@v3
     - uses: dtolnay/rust-toolchain@master
@@ -32,7 +32,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v3
-    - uses: dtolnay/rust-toolchain@1.56
+    - uses: dtolnay/rust-toolchain@1.63
       with:
         components: clippy
     - run: cargo clippy --workspace --all-features --all-targets -- -D warnings

--- a/.github/workflows/weekly.yml
+++ b/.github/workflows/weekly.yml
@@ -10,7 +10,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        rust: ["1.56", stable]
+        rust: ["1.63", stable]
     steps:
     - uses: actions/checkout@v3
     - uses: dtolnay/rust-toolchain@master

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -33,6 +33,9 @@ features = [
     "Win32_System_Kernel",
 ]
 
+[target.'cfg(unix)'.dependencies.libc]
+version = "0.2.151"
+
 [dev-dependencies]
 anyhow = "1.0.76"
 serde = { version = "1.0.160", features = ["derive"] }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,10 +14,25 @@ keywords = ["path"]
 categories = ["filesystem"]
 
 [features]
-default = []
+default = ["root"]
+root = ["dep:windows-sys"]
 
 [dependencies]
 serde = { version = "1.0.160", optional = true }
 
+[target.'cfg(windows)'.dependencies.windows-sys]
+version = "0.52.0"
+optional = true
+features = [
+    "Wdk_Foundation",
+    "Wdk_Storage_FileSystem",
+    "Win32_Foundation",
+    "Win32_Storage_FileSystem",
+    "Win32_System_IO",
+    "Win32_Security",
+    "Win32_System_Kernel",
+]
+
 [dev-dependencies]
+anyhow = "1.0.76"
 serde = { version = "1.0.160", features = ["derive"] }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,7 +3,7 @@ name = "relative-path"
 version = "1.9.0"
 authors = ["John-John Tedro <udoprog@tedro.se>"]
 edition = "2018"
-rust-version = "1.56"
+rust-version = "1.63"
 description = "Portable, relative paths for Rust."
 documentation = "https://docs.rs/relative-path"
 readme = "README.md"
@@ -15,7 +15,7 @@ categories = ["filesystem"]
 
 [features]
 default = ["root"]
-root = ["dep:windows-sys"]
+root = ["dep:windows-sys", "dep:libc"]
 
 [dependencies]
 serde = { version = "1.0.160", optional = true }
@@ -35,6 +35,7 @@ features = [
 
 [target.'cfg(unix)'.dependencies.libc]
 version = "0.2.151"
+optional = true
 
 [dev-dependencies]
 anyhow = "1.0.76"

--- a/examples/root.rs
+++ b/examples/root.rs
@@ -1,22 +1,18 @@
-use std::io::{Read, Seek, Write};
+use std::io::Read;
 
 use anyhow::{Context, Result};
 
 use relative_path::Root;
 
 fn main() -> Result<()> {
-    let root = Root::open(".")?;
+    let root = Root::new("..").context("Opening root directory")?;
 
     let mut cargo_toml = root
-        .open_options()
-        .write(true)
-        .append(true)
-        .open("test.txt")
+        .open("relative-path/Cargo.toml")
         .context("Opening file")?;
 
     let mut contents = String::new();
-    // cargo_toml.seek(std::io::SeekFrom::Start(0))?;
-    cargo_toml.write_all(b"Bye!\n")?;
+    cargo_toml.read_to_string(&mut contents)?;
     println!("{:?}", contents);
     Ok(())
 }

--- a/examples/root.rs
+++ b/examples/root.rs
@@ -1,0 +1,22 @@
+use std::io::{Read, Seek, Write};
+
+use anyhow::{Context, Result};
+
+use relative_path::Root;
+
+fn main() -> Result<()> {
+    let root = Root::open(".")?;
+
+    let mut cargo_toml = root
+        .open_options()
+        .write(true)
+        .append(true)
+        .open("test.txt")
+        .context("Opening file")?;
+
+    let mut contents = String::new();
+    // cargo_toml.seek(std::io::SeekFrom::Start(0))?;
+    cargo_toml.write_all(b"Bye!\n")?;
+    println!("{:?}", contents);
+    Ok(())
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -288,6 +288,12 @@
 
 mod path_ext;
 
+#[cfg(feature = "root")]
+#[doc(inline)]
+pub use self::root::Root;
+#[cfg(feature = "root")]
+mod root;
+
 #[cfg(test)]
 mod tests;
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -945,12 +945,14 @@ impl cmp::PartialEq for RelativePathBuf {
 impl cmp::Eq for RelativePathBuf {}
 
 impl cmp::PartialOrd for RelativePathBuf {
+    #[inline]
     fn partial_cmp(&self, other: &RelativePathBuf) -> Option<cmp::Ordering> {
-        self.components().partial_cmp(other.components())
+        Some(self.cmp(other))
     }
 }
 
 impl cmp::Ord for RelativePathBuf {
+    #[inline]
     fn cmp(&self, other: &RelativePathBuf) -> cmp::Ordering {
         self.components().cmp(other.components())
     }
@@ -1997,7 +1999,7 @@ impl cmp::Eq for RelativePath {}
 impl cmp::PartialOrd for RelativePath {
     #[inline]
     fn partial_cmp(&self, other: &RelativePath) -> Option<cmp::Ordering> {
-        self.components().partial_cmp(other.components())
+        Some(self.cmp(other))
     }
 }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -290,7 +290,7 @@ mod path_ext;
 
 #[cfg(feature = "root")]
 #[doc(inline)]
-pub use self::root::Root;
+pub use self::root::{OpenOptions, Root};
 #[cfg(feature = "root")]
 mod root;
 
@@ -386,7 +386,9 @@ pub enum Component<'a> {
 }
 
 impl<'a> Component<'a> {
-    /// Extracts the underlying [`str`][std::str] slice.
+    /// Extracts the underlying [`str`] slice.
+    ///
+    /// [`str`]: prim@str
     ///
     /// # Examples
     ///
@@ -549,10 +551,12 @@ impl<'a> cmp::PartialEq for Components<'a> {
     }
 }
 
-/// An iterator over the [`Component`]s of a [`RelativePath`], as
-/// [`str`][std::str] slices.
+/// An iterator over the [`Component`]s of a [`RelativePath`], as [`str`]
+/// slices.
 ///
 /// This `struct` is created by the [`iter`][RelativePath::iter] method.
+///
+/// [`str`]: prim@str
 #[derive(Clone)]
 pub struct Iter<'a> {
     inner: Components<'a>,
@@ -1051,7 +1055,9 @@ impl RelativePath {
         Ok(rel)
     }
 
-    /// Yields the underlying [`str`][std::str] slice.
+    /// Yields the underlying [`str`] slice.
+    ///
+    /// [`str`]: prim@str
     ///
     /// # Examples
     ///
@@ -1115,11 +1121,13 @@ impl RelativePath {
         Components::new(&self.inner)
     }
 
-    /// Produces an iterator over the path's components viewed as
-    /// [`str`][std::str] slices.
+    /// Produces an iterator over the path's components viewed as [`str`]
+    /// slices.
     ///
     /// For more information about the particulars of how the path is separated
     /// into components, see [`components`][Self::components].
+    ///
+    /// [`str`]: prim@str
     ///
     /// # Examples
     ///

--- a/src/root/mod.rs
+++ b/src/root/mod.rs
@@ -1,11 +1,19 @@
+// Some documentation copied from the Rust project under the MIT license.
+//
+// See https://github.com/rust-lang/rust
+
 use std::fs::File;
-use std::io;
+use std::io::{self, Read, Write};
 use std::path::Path;
 
 use crate::RelativePath;
 
 #[cfg_attr(windows, path = "windows.rs")]
+#[cfg_attr(unix, path = "unix.rs")]
 mod imp;
+
+#[cfg(not(any(windows, unix)))]
+compile_error!("root is only supported on cfg(windows) and cfg(unix)");
 
 /// An open root directory from which relative paths can be opened.
 ///
@@ -23,21 +31,178 @@ pub struct Root {
 impl Root {
     /// Open the given directory that can be used as a root for opening and
     /// manipulating relative paths.
-    pub fn open<P>(path: P) -> io::Result<Self>
+    ///
+    /// # Examples
+    ///
+    /// ```no_run
+    /// use relative_path::Root;
+    ///
+    /// let root = Root::new(".")?;
+    /// # Ok::<_, std::io::Error>(())
+    /// ```
+    pub fn new<P>(path: P) -> io::Result<Self>
     where
         P: AsRef<Path>,
     {
         Ok(Self {
-            inner: imp::Root::open(path)?,
+            inner: imp::Root::new(path)?,
         })
     }
 
     /// Construct an open options associated with this root.
+    ///
+    /// # Examples
+    ///
+    /// ```no_run
+    /// use relative_path::Root;
+    ///
+    /// let root = Root::new(".")?;
+    ///
+    /// let file = root.open_options().read(true).open("foo.txt");
+    /// # Ok::<_, std::io::Error>(())
+    /// ```
     pub fn open_options(&self) -> OpenOptions {
         OpenOptions {
             root: &self.inner,
             options: imp::OpenOptions::new(),
         }
+    }
+
+    /// Create the given file.
+    pub fn create<P>(&self, path: P) -> io::Result<File>
+    where
+        P: AsRef<RelativePath>,
+    {
+        self.open_options().write(true).create(true).open(path)
+    }
+
+    /// Open the given file for reading.
+    pub fn open<P>(&self, path: P) -> io::Result<File>
+    where
+        P: AsRef<RelativePath>,
+    {
+        self.open_options().read(true).open(path)
+    }
+
+    /// Read the entire contents of a file into a bytes vector.
+    ///
+    /// This is a convenience function for using [`File::open`] and
+    /// [`read_to_end`] with fewer imports and without an intermediate variable.
+    ///
+    /// [`read_to_end`]: Read::read_to_end
+    ///
+    /// # Errors
+    ///
+    /// This function will return an error if `path` does not already exist.
+    /// Other errors may also be returned according to [`OpenOptions::open`].
+    ///
+    /// While reading from the file, this function handles
+    /// [`io::ErrorKind::Interrupted`] with automatic retries. See [io::Read]
+    /// documentation for details.
+    ///
+    /// # Examples
+    ///
+    /// ```no_run
+    /// use std::net::SocketAddr;
+    ///
+    /// use relative_path::Root;
+    ///
+    /// let root = Root::new(".")?;
+    /// let foo: SocketAddr = String::from_utf8_lossy(&root.read("address.txt")?).parse()?;
+    /// # Ok::<_, Box<dyn std::error::Error>>(())
+    /// ```
+    pub fn read<P>(&self, path: P) -> io::Result<Vec<u8>>
+    where
+        P: AsRef<RelativePath>,
+    {
+        fn inner(this: &Root, path: &RelativePath) -> io::Result<Vec<u8>> {
+            let mut file = this.open(path)?;
+            let size = file.metadata().map(|m| m.len() as usize).ok();
+            let mut bytes = Vec::with_capacity(size.unwrap_or(0));
+            file.read_to_end(&mut bytes)?;
+            Ok(bytes)
+        }
+
+        inner(self, path.as_ref())
+    }
+
+    /// Read the entire contents of a file into a string.
+    ///
+    /// This is a convenience function for using [`File::open`] and
+    /// [`read_to_string`] with fewer imports and without an intermediate
+    /// variable.
+    ///
+    /// [`read_to_string`]: Read::read_to_string
+    ///
+    /// # Errors
+    ///
+    /// This function will return an error if `path` does not already exist.
+    /// Other errors may also be returned according to [`OpenOptions::open`].
+    ///
+    /// If the contents of the file are not valid UTF-8, then an error will also
+    /// be returned.
+    ///
+    /// While reading from the file, this function handles
+    /// [`io::ErrorKind::Interrupted`] with automatic retries. See [io::Read]
+    /// documentation for details.
+    ///
+    /// # Examples
+    ///
+    /// ```no_run
+    /// use std::net::SocketAddr;
+    ///
+    /// use relative_path::Root;
+    ///
+    /// let root = Root::new(".")?;
+    /// let foo: SocketAddr = root.read_to_string("address.txt")?.parse()?;
+    /// # Ok::<_, Box<dyn std::error::Error>>(())
+    /// ```
+    pub fn read_to_string<P>(&self, path: P) -> io::Result<String>
+    where
+        P: AsRef<RelativePath>,
+    {
+        fn inner(this: &Root, path: &RelativePath) -> io::Result<String> {
+            let mut file = this.open(path)?;
+            let size = file.metadata().map(|m| m.len() as usize).ok();
+            let mut string = String::with_capacity(size.unwrap_or(0));
+            file.read_to_string(&mut string)?;
+            Ok(string)
+        }
+
+        inner(self, path.as_ref())
+    }
+
+    /// Write a slice as the entire contents of a file.
+    ///
+    /// This function will create a file if it does not exist,
+    /// and will entirely replace its contents if it does.
+    ///
+    /// Depending on the platform, this function may fail if the
+    /// full directory path does not exist.
+    ///
+    /// This is a convenience function for using [`File::create`] and
+    /// [`write_all`] with fewer imports.
+    ///
+    /// [`write_all`]: Write::write_all
+    ///
+    /// # Examples
+    ///
+    /// ```no_run
+    /// use relative_path::Root;
+    ///
+    /// let root = Root::new(".")?;
+    ///
+    /// root.write("foo.txt", b"Lorem ipsum")?;
+    /// root.write("bar.txt", "dolor sit")?;
+    /// # Ok::<_, std::io::Error>(())
+    /// ```
+    /// ```
+    pub fn write<P, C>(&self, path: P, contents: C) -> io::Result<()>
+    where
+        P: AsRef<RelativePath>,
+        C: AsRef<[u8]>,
+    {
+        self.create(path)?.write_all(contents.as_ref())
     }
 }
 
@@ -49,7 +214,7 @@ impl Root {
 /// builder.
 ///
 /// Generally speaking, when using `OpenOptions`, you'll first call
-/// [`OpenOptions::new`], then chain calls to methods to set each option, then
+/// [`Root::open_options`], then chain calls to methods to set each option, then
 /// call [`OpenOptions::open`], passing the path of the file you're trying to
 /// open. This will give you a [`io::Result`] with a [`File`] inside that you
 /// can further operate on.
@@ -59,22 +224,29 @@ impl Root {
 /// Opening a file to read:
 ///
 /// ```no_run
-/// use relative_path::OpenOptions;
+/// use relative_path::Root;
 ///
-/// let file = OpenOptions::new().read(true).open("foo.txt");
+/// let root = Root::new(".")?;
+///
+/// let file = root.open_options().read(true).open("foo.txt");
+/// # Ok::<_, std::io::Error>(())
 /// ```
 ///
 /// Opening a file for both reading and writing, as well as creating it if it
 /// doesn't exist:
 ///
 /// ```no_run
-/// use relative_path::OpenOptions;
+/// use relative_path::Root;
 ///
-/// let file = OpenOptions::new()
-///             .read(true)
-///             .write(true)
-///             .create(true)
-///             .open("foo.txt");
+/// let root = Root::new(".")?;
+///
+/// let file = root
+///     .open_options()
+///     .read(true)
+///     .write(true)
+///     .create(true)
+///     .open("foo.txt")?;
+/// # Ok::<_, std::io::Error>(())
 /// ```
 #[derive(Clone, Debug)]
 pub struct OpenOptions<'a> {
@@ -91,9 +263,12 @@ impl<'a> OpenOptions<'a> {
     /// # Examples
     ///
     /// ```no_run
-    /// use relative_path::OpenOptions;
+    /// use relative_path::Root;
     ///
-    /// let file = OpenOptions::new().read(true).open("foo.txt");
+    /// let root = Root::new(".")?;
+    ///
+    /// let file = root.open_options().read(true).open("foo.txt");
+    /// # Ok::<_, std::io::Error>(())
     /// ```
     pub fn read(&mut self, read: bool) -> &mut Self {
         self.options.read(read);
@@ -111,9 +286,12 @@ impl<'a> OpenOptions<'a> {
     /// # Examples
     ///
     /// ```no_run
-    /// use relative_path::OpenOptions;
+    /// use relative_path::Root;
     ///
-    /// let file = OpenOptions::new().write(true).open("foo.txt");
+    /// let root = Root::new(".")?;
+    ///
+    /// let file = root.open_options().write(true).open("foo.txt");
+    /// # Ok::<_, std::io::Error>(())
     /// ```
     pub fn write(&mut self, write: bool) -> &mut Self {
         self.options.write(write);
@@ -123,24 +301,25 @@ impl<'a> OpenOptions<'a> {
     /// Sets the option for the append mode.
     ///
     /// This option, when true, means that writes will append to a file instead
-    /// of overwriting previous contents.
-    /// Note that setting `.write(true).append(true)` has the same effect as
-    /// setting only `.append(true)`.
+    /// of overwriting previous contents. Note that setting
+    /// `.write(true).append(true)` has the same effect as setting only
+    /// `.append(true)`.
     ///
-    /// For most filesystems, the operating system guarantees that all writes are
-    /// atomic: no writes get mangled because another process writes at the same
-    /// time.
+    /// For most filesystems, the operating system guarantees that all writes
+    /// are atomic: no writes get mangled because another process writes at the
+    /// same time.
     ///
     /// One maybe obvious note when using append-mode: make sure that all data
-    /// that belongs together is written to the file in one operation. This
-    /// can be done by concatenating strings before passing them to [`write()`],
-    /// or using a buffered writer (with a buffer of adequate size),
-    /// and calling [`flush()`] when the message is complete.
+    /// that belongs together is written to the file in one operation. This can
+    /// be done by concatenating strings before passing them to [`write()`], or
+    /// using a buffered writer (with a buffer of adequate size), and calling
+    /// [`flush()`] when the message is complete.
     ///
     /// If a file is opened with both read and append access, beware that after
-    /// opening, and after every write, the position for reading may be set at the
-    /// end of the file. So, before writing, save the current position (using
-    /// <code>[seek]\([SeekFrom]::[Current]\(0))</code>), and restore it before the next read.
+    /// opening, and after every write, the position for reading may be set at
+    /// the end of the file. So, before writing, save the current position
+    /// (using <code>[seek]\([SeekFrom]::[Current]\(0))</code>), and restore it
+    /// before the next read.
     ///
     /// ## Note
     ///
@@ -149,15 +328,19 @@ impl<'a> OpenOptions<'a> {
     ///
     /// [`write()`]: Write::write "io::Write::write"
     /// [`flush()`]: Write::flush "io::Write::flush"
-    /// [seek]: Seek::seek "io::Seek::seek"
-    /// [Current]: SeekFrom::Current "io::SeekFrom::Current"
+    /// [seek]: std::io::Seek::seek "io::Seek::seek"
+    /// [SeekFrom]: std::io::SeekFrom
+    /// [Current]: std::io::SeekFrom::Current
     ///
     /// # Examples
     ///
     /// ```no_run
-    /// use relative_path::OpenOptions;
+    /// use relative_path::Root;
     ///
-    /// let file = OpenOptions::new().append(true).open("foo.txt");
+    /// let root = Root::new(".")?;
+    ///
+    /// let file = root.open_options().append(true).open("foo.txt");
+    /// # Ok::<_, std::io::Error>(())
     /// ```
     pub fn append(&mut self, append: bool) -> &mut Self {
         self.options.append(append);
@@ -174,9 +357,12 @@ impl<'a> OpenOptions<'a> {
     /// # Examples
     ///
     /// ```no_run
-    /// use relative_path::OpenOptions;
+    /// use relative_path::Root;
     ///
-    /// let file = OpenOptions::new().write(true).truncate(true).open("foo.txt");
+    /// let root = Root::new(".")?;
+    ///
+    /// let file = root.open_options().write(true).truncate(true).open("foo.txt");
+    /// # Ok::<_, std::io::Error>(())
     /// ```
     pub fn truncate(&mut self, truncate: bool) -> &mut Self {
         self.options.truncate(truncate);
@@ -188,15 +374,18 @@ impl<'a> OpenOptions<'a> {
     /// In order for the file to be created, [`OpenOptions::write`] or
     /// [`OpenOptions::append`] access must be used.
     ///
-    /// See also [`relative_path::write()`][self::write] for a simple function to
-    /// create a file with a given data.
+    /// See also [`Root::write()`] for a simple function to create a file with a
+    /// given data.
     ///
     /// # Examples
     ///
     /// ```no_run
-    /// use relative_path::OpenOptions;
+    /// use relative_path::Root;
     ///
-    /// let file = OpenOptions::new().write(true).create(true).open("foo.txt");
+    /// let root = Root::new(".")?;
+    ///
+    /// let file = root.open_options().write(true).create(true).open("foo.txt");
+    /// # Ok::<_, std::io::Error>(())
     /// ```
     pub fn create(&mut self, create: bool) -> &mut Self {
         self.options.create(create);
@@ -224,11 +413,12 @@ impl<'a> OpenOptions<'a> {
     /// # Examples
     ///
     /// ```no_run
-    /// use relative_path::OpenOptions;
+    /// use relative_path::Root;
     ///
-    /// let file = OpenOptions::new().write(true)
-    ///                              .create_new(true)
-    ///                              .open("foo.txt");
+    /// let root = Root::new(".")?;
+    ///
+    /// let file = root.open_options().write(true).create_new(true).open("foo.txt");
+    /// # Ok::<_, std::io::Error>(())
     /// ```
     pub fn create_new(&mut self, create_new: bool) -> &mut Self {
         self.options.create_new(create_new);
@@ -268,9 +458,12 @@ impl<'a> OpenOptions<'a> {
     /// # Examples
     ///
     /// ```no_run
-    /// use relative_path::OpenOptions;
+    /// use relative_path::Root;
     ///
-    /// let file = OpenOptions::new().read(true).open("foo.txt");
+    /// let root = Root::new(".")?;
+    ///
+    /// let file = root.open_options().read(true).open("foo.txt");
+    /// # Ok::<_, std::io::Error>(())
     /// ```
     ///
     /// [`AlreadyExists`]: io::ErrorKind::AlreadyExists

--- a/src/root/mod.rs
+++ b/src/root/mod.rs
@@ -1,0 +1,286 @@
+use std::fs::File;
+use std::io;
+use std::path::Path;
+
+use crate::RelativePath;
+
+#[cfg_attr(windows, path = "windows.rs")]
+mod imp;
+
+/// An open root directory from which relative paths can be opened.
+///
+/// In contrast to using APIs such as [`RelativePath::to_path`], this does not
+/// require allocations to open a path.
+///
+/// This is achieved by keeping an open handle to the directory and using
+/// platform-specific APIs to open a relative path, such as [`openat`] on `unix`.
+///
+/// [`openat`]: https://linux.die.net/man/2/openat
+pub struct Root {
+    inner: imp::Root,
+}
+
+impl Root {
+    /// Open the given directory that can be used as a root for opening and
+    /// manipulating relative paths.
+    pub fn open<P>(path: P) -> io::Result<Self>
+    where
+        P: AsRef<Path>,
+    {
+        Ok(Self {
+            inner: imp::Root::open(path)?,
+        })
+    }
+
+    /// Construct an open options associated with this root.
+    pub fn open_options(&self) -> OpenOptions {
+        OpenOptions {
+            root: &self.inner,
+            options: imp::OpenOptions::new(),
+        }
+    }
+}
+
+/// Options and flags which can be used to configure how a file is opened.
+///
+/// This builder exposes the ability to configure how a [`File`] is opened and
+/// what operations are permitted on the open file. The [`File::open`] and
+/// [`File::create`] methods are aliases for commonly used options using this
+/// builder.
+///
+/// Generally speaking, when using `OpenOptions`, you'll first call
+/// [`OpenOptions::new`], then chain calls to methods to set each option, then
+/// call [`OpenOptions::open`], passing the path of the file you're trying to
+/// open. This will give you a [`io::Result`] with a [`File`] inside that you
+/// can further operate on.
+///
+/// # Examples
+///
+/// Opening a file to read:
+///
+/// ```no_run
+/// use relative_path::OpenOptions;
+///
+/// let file = OpenOptions::new().read(true).open("foo.txt");
+/// ```
+///
+/// Opening a file for both reading and writing, as well as creating it if it
+/// doesn't exist:
+///
+/// ```no_run
+/// use relative_path::OpenOptions;
+///
+/// let file = OpenOptions::new()
+///             .read(true)
+///             .write(true)
+///             .create(true)
+///             .open("foo.txt");
+/// ```
+#[derive(Clone, Debug)]
+pub struct OpenOptions<'a> {
+    root: &'a imp::Root,
+    options: imp::OpenOptions,
+}
+
+impl<'a> OpenOptions<'a> {
+    /// Sets the option for read access.
+    ///
+    /// This option, when true, will indicate that the file should be
+    /// `read`-able if opened.
+    ///
+    /// # Examples
+    ///
+    /// ```no_run
+    /// use relative_path::OpenOptions;
+    ///
+    /// let file = OpenOptions::new().read(true).open("foo.txt");
+    /// ```
+    pub fn read(&mut self, read: bool) -> &mut Self {
+        self.options.read(read);
+        self
+    }
+
+    /// Sets the option for write access.
+    ///
+    /// This option, when true, will indicate that the file should be
+    /// `write`-able if opened.
+    ///
+    /// If the file already exists, any write calls on it will overwrite its
+    /// contents, without truncating it.
+    ///
+    /// # Examples
+    ///
+    /// ```no_run
+    /// use relative_path::OpenOptions;
+    ///
+    /// let file = OpenOptions::new().write(true).open("foo.txt");
+    /// ```
+    pub fn write(&mut self, write: bool) -> &mut Self {
+        self.options.write(write);
+        self
+    }
+
+    /// Sets the option for the append mode.
+    ///
+    /// This option, when true, means that writes will append to a file instead
+    /// of overwriting previous contents.
+    /// Note that setting `.write(true).append(true)` has the same effect as
+    /// setting only `.append(true)`.
+    ///
+    /// For most filesystems, the operating system guarantees that all writes are
+    /// atomic: no writes get mangled because another process writes at the same
+    /// time.
+    ///
+    /// One maybe obvious note when using append-mode: make sure that all data
+    /// that belongs together is written to the file in one operation. This
+    /// can be done by concatenating strings before passing them to [`write()`],
+    /// or using a buffered writer (with a buffer of adequate size),
+    /// and calling [`flush()`] when the message is complete.
+    ///
+    /// If a file is opened with both read and append access, beware that after
+    /// opening, and after every write, the position for reading may be set at the
+    /// end of the file. So, before writing, save the current position (using
+    /// <code>[seek]\([SeekFrom]::[Current]\(0))</code>), and restore it before the next read.
+    ///
+    /// ## Note
+    ///
+    /// This function doesn't create the file if it doesn't exist. Use the
+    /// [`OpenOptions::create`] method to do so.
+    ///
+    /// [`write()`]: Write::write "io::Write::write"
+    /// [`flush()`]: Write::flush "io::Write::flush"
+    /// [seek]: Seek::seek "io::Seek::seek"
+    /// [Current]: SeekFrom::Current "io::SeekFrom::Current"
+    ///
+    /// # Examples
+    ///
+    /// ```no_run
+    /// use relative_path::OpenOptions;
+    ///
+    /// let file = OpenOptions::new().append(true).open("foo.txt");
+    /// ```
+    pub fn append(&mut self, append: bool) -> &mut Self {
+        self.options.append(append);
+        self
+    }
+
+    /// Sets the option for truncating a previous file.
+    ///
+    /// If a file is successfully opened with this option set it will truncate
+    /// the file to 0 length if it already exists.
+    ///
+    /// The file must be opened with write access for truncate to work.
+    ///
+    /// # Examples
+    ///
+    /// ```no_run
+    /// use relative_path::OpenOptions;
+    ///
+    /// let file = OpenOptions::new().write(true).truncate(true).open("foo.txt");
+    /// ```
+    pub fn truncate(&mut self, truncate: bool) -> &mut Self {
+        self.options.truncate(truncate);
+        self
+    }
+
+    /// Sets the option to create a new file, or open it if it already exists.
+    ///
+    /// In order for the file to be created, [`OpenOptions::write`] or
+    /// [`OpenOptions::append`] access must be used.
+    ///
+    /// See also [`relative_path::write()`][self::write] for a simple function to
+    /// create a file with a given data.
+    ///
+    /// # Examples
+    ///
+    /// ```no_run
+    /// use relative_path::OpenOptions;
+    ///
+    /// let file = OpenOptions::new().write(true).create(true).open("foo.txt");
+    /// ```
+    pub fn create(&mut self, create: bool) -> &mut Self {
+        self.options.create(create);
+        self
+    }
+
+    /// Sets the option to create a new file, failing if it already exists.
+    ///
+    /// No file is allowed to exist at the target location, also no (dangling) symlink. In this
+    /// way, if the call succeeds, the file returned is guaranteed to be new.
+    ///
+    /// This option is useful because it is atomic. Otherwise between checking
+    /// whether a file exists and creating a new one, the file may have been
+    /// created by another process (a TOCTOU race condition / attack).
+    ///
+    /// If `.create_new(true)` is set, [`.create()`] and [`.truncate()`] are
+    /// ignored.
+    ///
+    /// The file must be opened with write or append access in order to create
+    /// a new file.
+    ///
+    /// [`.create()`]: OpenOptions::create
+    /// [`.truncate()`]: OpenOptions::truncate
+    ///
+    /// # Examples
+    ///
+    /// ```no_run
+    /// use relative_path::OpenOptions;
+    ///
+    /// let file = OpenOptions::new().write(true)
+    ///                              .create_new(true)
+    ///                              .open("foo.txt");
+    /// ```
+    pub fn create_new(&mut self, create_new: bool) -> &mut Self {
+        self.options.create_new(create_new);
+        self
+    }
+
+    /// Opens a file at `path` with the options specified by `self`.
+    ///
+    /// # Errors
+    ///
+    /// This function will return an error under a number of different
+    /// circumstances. Some of these error conditions are listed here, together
+    /// with their [`io::ErrorKind`]. The mapping to [`io::ErrorKind`]s is not
+    /// part of the compatibility contract of the function.
+    ///
+    /// * [`NotFound`]: The specified file does not exist and neither `create`
+    ///   or `create_new` is set.
+    /// * [`NotFound`]: One of the directory components of the file path does
+    ///   not exist.
+    /// * [`PermissionDenied`]: The user lacks permission to get the specified
+    ///   access rights for the file.
+    /// * [`PermissionDenied`]: The user lacks permission to open one of the
+    ///   directory components of the specified path.
+    /// * [`AlreadyExists`]: `create_new` was specified and the file already
+    ///   exists.
+    /// * [`InvalidInput`]: Invalid combinations of open options (truncate
+    ///   without write access, no access mode set, etc.).
+    ///
+    /// The following errors don't match any existing [`io::ErrorKind`] at the moment:
+    /// * One of the directory components of the specified file path
+    ///   was not, in fact, a directory.
+    /// * Filesystem-level errors: full disk, write permission
+    ///   requested on a read-only file system, exceeded disk quota, too many
+    ///   open files, too long filename, too many symbolic links in the
+    ///   specified path (Unix-like systems only), etc.
+    ///
+    /// # Examples
+    ///
+    /// ```no_run
+    /// use relative_path::OpenOptions;
+    ///
+    /// let file = OpenOptions::new().read(true).open("foo.txt");
+    /// ```
+    ///
+    /// [`AlreadyExists`]: io::ErrorKind::AlreadyExists
+    /// [`InvalidInput`]: io::ErrorKind::InvalidInput
+    /// [`NotFound`]: io::ErrorKind::NotFound
+    /// [`PermissionDenied`]: io::ErrorKind::PermissionDenied
+    pub fn open<P>(&self, path: P) -> io::Result<File>
+    where
+        P: AsRef<RelativePath>,
+    {
+        self.root.open_at(path, &self.options)
+    }
+}

--- a/src/root/unix.rs
+++ b/src/root/unix.rs
@@ -1,0 +1,167 @@
+use std::ffi::CString;
+use std::fs::File;
+use std::io;
+use std::os::fd::AsRawFd;
+use std::os::fd::FromRawFd;
+use std::os::fd::OwnedFd;
+use std::path::Path;
+
+use crate::{Component, RelativePath};
+
+#[derive(Debug)]
+pub(super) struct Root {
+    handle: OwnedFd,
+}
+
+impl Root {
+    pub(super) fn new<P>(path: P) -> io::Result<Self>
+    where
+        P: AsRef<Path>,
+    {
+        let file = std::fs::OpenOptions::new().read(true).open(path)?;
+
+        Ok(Root {
+            handle: OwnedFd::from(file),
+        })
+    }
+
+    pub(super) fn open_at<P>(&self, path: P, options: &OpenOptions) -> io::Result<File>
+    where
+        P: AsRef<RelativePath>,
+    {
+        let path = convert_to_c_string(path.as_ref())?;
+
+        let flags = libc::O_CLOEXEC | options.get_creation_mode()? | options.get_access_mode()?;
+
+        unsafe {
+            let fd = libc::openat(self.handle.as_raw_fd(), path.as_ptr(), flags);
+
+            if fd == -1 {
+                return Err(io::Error::last_os_error());
+            }
+
+            Ok(File::from_raw_fd(fd))
+        }
+    }
+}
+
+fn convert_to_c_string(input: &RelativePath) -> io::Result<CString> {
+    let mut path = Vec::new();
+
+    for c in input.components() {
+        if !path.is_empty() {
+            path.push(b'/');
+        }
+
+        match c {
+            Component::CurDir => {}
+            Component::ParentDir => {
+                if path.is_empty() {
+                    return Err(io::Error::from_raw_os_error(libc::EINVAL));
+                }
+
+                let index = path.iter().rposition(|&b| b == b'/').unwrap_or(0);
+                path.truncate(index);
+            }
+            Component::Normal(normal) => {
+                if normal.as_bytes().contains(&b'\0') {
+                    return Err(io::Error::from_raw_os_error(libc::EINVAL));
+                }
+
+                path.extend_from_slice(normal.as_bytes());
+            }
+        }
+    }
+
+    path.push(0);
+
+    // SAFETY: We've checked safety requirements of CString above.
+    unsafe { Ok(CString::from_vec_with_nul_unchecked(path)) }
+}
+
+unsafe impl Send for OpenOptions {}
+unsafe impl Sync for OpenOptions {}
+
+#[derive(Clone, Debug)]
+pub(super) struct OpenOptions {
+    // generic
+    read: bool,
+    write: bool,
+    append: bool,
+    truncate: bool,
+    create: bool,
+    create_new: bool,
+}
+
+impl OpenOptions {
+    pub(super) fn new() -> OpenOptions {
+        OpenOptions {
+            // generic
+            read: false,
+            write: false,
+            append: false,
+            truncate: false,
+            create: false,
+            create_new: false,
+        }
+    }
+
+    pub(super) fn read(&mut self, read: bool) {
+        self.read = read;
+    }
+
+    pub(super) fn write(&mut self, write: bool) {
+        self.write = write;
+    }
+
+    pub(super) fn append(&mut self, append: bool) {
+        self.append = append;
+    }
+
+    pub(super) fn truncate(&mut self, truncate: bool) {
+        self.truncate = truncate;
+    }
+
+    pub(super) fn create(&mut self, create: bool) {
+        self.create = create;
+    }
+
+    pub(super) fn create_new(&mut self, create_new: bool) {
+        self.create_new = create_new;
+    }
+
+    fn get_access_mode(&self) -> io::Result<i32> {
+        match (self.read, self.write, self.append) {
+            (true, false, false) => Ok(libc::O_RDONLY),
+            (false, true, false) => Ok(libc::O_WRONLY),
+            (true, true, false) => Ok(libc::O_RDWR),
+            (false, _, true) => Ok(libc::O_WRONLY | libc::O_APPEND),
+            (true, _, true) => Ok(libc::O_RDWR | libc::O_APPEND),
+            (false, false, false) => Err(io::Error::from_raw_os_error(libc::EINVAL)),
+        }
+    }
+
+    fn get_creation_mode(&self) -> io::Result<i32> {
+        match (self.write, self.append) {
+            (true, false) => {}
+            (false, false) => {
+                if self.truncate || self.create || self.create_new {
+                    return Err(io::Error::from_raw_os_error(libc::EINVAL));
+                }
+            }
+            (_, true) => {
+                if self.truncate && !self.create_new {
+                    return Err(io::Error::from_raw_os_error(libc::EINVAL));
+                }
+            }
+        }
+
+        Ok(match (self.create, self.truncate, self.create_new) {
+            (false, false, false) => 0,
+            (true, false, false) => libc::O_CREAT,
+            (false, true, false) => libc::O_TRUNC,
+            (true, true, false) => libc::O_CREAT | libc::O_TRUNC,
+            (_, _, true) => libc::O_CREAT | libc::O_EXCL,
+        })
+    }
+}

--- a/src/root/windows.rs
+++ b/src/root/windows.rs
@@ -1,0 +1,211 @@
+use std::ffi::c_void;
+use std::ffi::OsStr;
+use std::fs::File;
+use std::io;
+use std::mem;
+use std::mem::size_of;
+use std::mem::MaybeUninit;
+use std::os::windows::ffi::OsStrExt;
+use std::os::windows::fs::OpenOptionsExt;
+use std::os::windows::io::{AsRawHandle, FromRawHandle, OwnedHandle};
+use std::path::Path;
+use std::ptr;
+
+use windows_sys::Wdk::Foundation::OBJECT_ATTRIBUTES;
+use windows_sys::Wdk::Storage::FileSystem::FILE_SYNCHRONOUS_IO_ALERT;
+use windows_sys::Wdk::Storage::FileSystem::{self as nt, NtCreateFile};
+use windows_sys::Win32::Foundation::STATUS_SUCCESS;
+use windows_sys::Win32::Foundation::{
+    RtlNtStatusToDosError, ERROR_INVALID_PARAMETER, HANDLE, STATUS_PENDING, UNICODE_STRING,
+};
+use windows_sys::Win32::Storage::FileSystem as c;
+use windows_sys::Win32::System::IO::IO_STATUS_BLOCK;
+
+use crate::RelativePath;
+
+type DWORD = u32;
+
+#[derive(Debug)]
+pub(super) struct Root {
+    handle: OwnedHandle,
+}
+
+impl Root {
+    pub(super) fn open<P>(path: P) -> io::Result<Self>
+    where
+        P: AsRef<Path>,
+    {
+        let file = std::fs::OpenOptions::new()
+            .read(true)
+            .attributes(c::FILE_FLAG_BACKUP_SEMANTICS)
+            .open(path)?;
+        let handle = OwnedHandle::from(file);
+        Ok(Root { handle })
+    }
+
+    pub(super) fn open_at<P>(&self, path: P, options: &OpenOptions) -> io::Result<File>
+    where
+        P: AsRef<RelativePath>,
+    {
+        let object_name = OsStr::new(path.as_ref().as_str())
+            .encode_wide()
+            .collect::<Vec<u16>>();
+
+        unsafe {
+            let len = mem::size_of_val(&object_name[..]);
+
+            let string = UNICODE_STRING {
+                Length: len as u16,
+                MaximumLength: len as u16,
+                Buffer: object_name.as_ptr() as *mut u16,
+            };
+
+            let attributes = OBJECT_ATTRIBUTES {
+                Length: size_of::<OBJECT_ATTRIBUTES>() as u32,
+                RootDirectory: self.handle.as_raw_handle() as HANDLE,
+                ObjectName: &string,
+                Attributes: 0,
+                SecurityDescriptor: ptr::null(),
+                SecurityQualityOfService: ptr::null(),
+            };
+
+            let mut status_block = IO_STATUS_BLOCK {
+                Anonymous: windows_sys::Win32::System::IO::IO_STATUS_BLOCK_0 {
+                    Status: STATUS_PENDING,
+                },
+                Information: 0,
+            };
+
+            let mut handle = MaybeUninit::zeroed();
+
+            let status = NtCreateFile(
+                handle.as_mut_ptr(),
+                options.get_access_mode()?,
+                &attributes,
+                &mut status_block,
+                ptr::null_mut(),
+                0,
+                options.share_mode,
+                options.get_creation_mode()?,
+                FILE_SYNCHRONOUS_IO_ALERT,
+                ptr::null(),
+                0,
+            );
+
+            if status != STATUS_SUCCESS {
+                return Err(io::Error::from_raw_os_error(
+                    RtlNtStatusToDosError(status) as i32
+                ));
+            }
+
+            let handle = handle.assume_init();
+            Ok(File::from_raw_handle(handle as *mut c_void))
+        }
+    }
+}
+
+unsafe impl Send for OpenOptions {}
+unsafe impl Sync for OpenOptions {}
+
+#[derive(Clone, Debug)]
+pub(super) struct OpenOptions {
+    // generic
+    read: bool,
+    write: bool,
+    append: bool,
+    truncate: bool,
+    create: bool,
+    create_new: bool,
+    // system-specific
+    share_mode: DWORD,
+}
+
+impl OpenOptions {
+    pub(super) fn new() -> OpenOptions {
+        OpenOptions {
+            // generic
+            read: false,
+            write: false,
+            append: false,
+            truncate: false,
+            create: false,
+            create_new: false,
+            // system-specific
+            share_mode: c::FILE_SHARE_READ | c::FILE_SHARE_WRITE | c::FILE_SHARE_DELETE,
+        }
+    }
+
+    pub(super) fn read(&mut self, read: bool) {
+        self.read = read;
+    }
+
+    pub(super) fn write(&mut self, write: bool) {
+        self.write = write;
+    }
+
+    pub(super) fn append(&mut self, append: bool) {
+        self.append = append;
+    }
+
+    pub(super) fn truncate(&mut self, truncate: bool) {
+        self.truncate = truncate;
+    }
+
+    pub(super) fn create(&mut self, create: bool) {
+        self.create = create;
+    }
+
+    pub(super) fn create_new(&mut self, create_new: bool) {
+        self.create_new = create_new;
+    }
+
+    fn get_access_mode(&self) -> io::Result<DWORD> {
+        // NtCreateFile does not support `GENERIC_READ`.
+        const DEFAULT_READ: DWORD = c::STANDARD_RIGHTS_READ
+            | c::SYNCHRONIZE
+            | c::FILE_READ_DATA
+            | c::FILE_READ_EA
+            | c::FILE_READ_ATTRIBUTES;
+
+        const DEFAULT_WRITE: DWORD = c::STANDARD_RIGHTS_WRITE
+            | c::SYNCHRONIZE
+            | c::FILE_WRITE_DATA
+            | c::FILE_WRITE_EA
+            | c::FILE_WRITE_ATTRIBUTES;
+
+        match (self.read, self.write, self.append) {
+            (true, false, false) => Ok(DEFAULT_READ),
+            (false, true, false) => Ok(DEFAULT_WRITE),
+            (true, true, false) => Ok(DEFAULT_READ | DEFAULT_WRITE),
+            (false, _, true) => Ok(c::FILE_GENERIC_WRITE & !c::FILE_WRITE_DATA),
+            (true, _, true) => Ok(DEFAULT_READ | (c::FILE_GENERIC_WRITE & !c::FILE_WRITE_DATA)),
+            (false, false, false) => {
+                Err(io::Error::from_raw_os_error(ERROR_INVALID_PARAMETER as i32))
+            }
+        }
+    }
+
+    fn get_creation_mode(&self) -> io::Result<DWORD> {
+        match (self.write, self.append) {
+            (true, false) => {}
+            (false, false) => {
+                if self.truncate || self.create || self.create_new {
+                    return Err(io::Error::from_raw_os_error(ERROR_INVALID_PARAMETER as i32));
+                }
+            }
+            (_, true) => {
+                if self.truncate && !self.create_new {
+                    return Err(io::Error::from_raw_os_error(ERROR_INVALID_PARAMETER as i32));
+                }
+            }
+        }
+
+        Ok(match (self.create, self.truncate, self.create_new) {
+            (false, false, false) => nt::FILE_OPEN,
+            (true, false, false) => nt::FILE_OPEN_IF,
+            (false, true, false) => nt::FILE_OVERWRITE,
+            (true, true, false) => nt::FILE_OVERWRITE_IF,
+            (_, _, true) => nt::FILE_CREATE,
+        })
+    }
+}

--- a/src/root/windows.rs
+++ b/src/root/windows.rs
@@ -24,8 +24,6 @@ use windows_sys::Win32::System::IO::IO_STATUS_BLOCK;
 use crate::Component;
 use crate::RelativePath;
 
-type DWORD = u32;
-
 #[derive(Debug)]
 pub(super) struct Root {
     handle: OwnedHandle,
@@ -158,7 +156,7 @@ pub(super) struct OpenOptions {
     create: bool,
     create_new: bool,
     // system-specific
-    share_mode: DWORD,
+    share_mode: u32,
 }
 
 impl OpenOptions {
@@ -200,15 +198,15 @@ impl OpenOptions {
         self.create_new = create_new;
     }
 
-    fn get_access_mode(&self) -> io::Result<DWORD> {
+    fn get_access_mode(&self) -> io::Result<u32> {
         // NtCreateFile does not support `GENERIC_READ`.
-        const DEFAULT_READ: DWORD = c::STANDARD_RIGHTS_READ
+        const DEFAULT_READ: u32 = c::STANDARD_RIGHTS_READ
             | c::SYNCHRONIZE
             | c::FILE_READ_DATA
             | c::FILE_READ_EA
             | c::FILE_READ_ATTRIBUTES;
 
-        const DEFAULT_WRITE: DWORD = c::STANDARD_RIGHTS_WRITE
+        const DEFAULT_WRITE: u32 = c::STANDARD_RIGHTS_WRITE
             | c::SYNCHRONIZE
             | c::FILE_WRITE_DATA
             | c::FILE_WRITE_EA
@@ -226,7 +224,7 @@ impl OpenOptions {
         }
     }
 
-    fn get_creation_mode(&self) -> io::Result<DWORD> {
+    fn get_creation_mode(&self) -> io::Result<u32> {
         match (self.write, self.append) {
             (true, false) => {}
             (false, false) => {

--- a/src/root/windows.rs
+++ b/src/root/windows.rs
@@ -8,7 +8,6 @@ use std::os::windows::fs::OpenOptionsExt;
 use std::os::windows::io::{AsRawHandle, FromRawHandle, OwnedHandle};
 use std::path::Path;
 use std::path::MAIN_SEPARATOR;
-use std::path::MAIN_SEPARATOR_STR;
 use std::ptr;
 
 use windows_sys::Wdk::Foundation::OBJECT_ATTRIBUTES;
@@ -117,7 +116,7 @@ where
 
     for c in path.components() {
         if !output.is_empty() {
-            output.extend(MAIN_SEPARATOR_STR.encode_utf16());
+            output.extend_from_slice(MAIN_SEPARATOR.encode_utf16(&mut [0; 2]));
         }
 
         match c {

--- a/tests/root.rs
+++ b/tests/root.rs
@@ -1,0 +1,52 @@
+use std::fs;
+use std::path::{Path, PathBuf};
+
+use anyhow::Result;
+use relative_path::Root;
+
+const PATH: &str = env!("CARGO_TARGET_TMPDIR");
+
+fn make_path(path: &'static str) -> PathBuf {
+    Path::new(PATH).join(path)
+}
+
+fn root(path: &'static str) -> Root {
+    match Root::new(make_path(path)) {
+        Ok(root) => root,
+        Err(error) => panic!("Failed to open root: {}: {}", path, error),
+    }
+}
+
+fn files(list: &[(&'static str, Option<&'static str>)]) {
+    for (item, content) in list {
+        let path = make_path(item);
+
+        if let Some(content) = content {
+            if let Some(parent) = path.parent() {
+                if let Err(error) = fs::create_dir_all(&parent) {
+                    panic!("Failed to create directory {}: {}", parent.display(), error);
+                }
+            }
+
+            if let Err(error) = fs::write(&path, content) {
+                panic!("Failed to create file {}: {}", path.display(), error);
+            }
+        } else {
+            if let Err(error) = fs::create_dir_all(&path) {
+                panic!("Failed to create directory {}: {}", path.display(), error);
+            }
+        }
+    }
+}
+
+#[test]
+fn relative_open() -> Result<()> {
+    files(&[("src/root/first", Some("first content"))]);
+
+    let r1 = root("src/root");
+    assert_eq!(r1.read_to_string("first")?, "first content");
+
+    let r2 = root("src");
+    assert_eq!(r2.read_to_string("root/first")?, "first content");
+    Ok(())
+}

--- a/tests/root.rs
+++ b/tests/root.rs
@@ -23,7 +23,7 @@ fn files(list: &[(&'static str, Option<&'static str>)]) {
 
         if let Some(content) = content {
             if let Some(parent) = path.parent() {
-                if let Err(error) = fs::create_dir_all(&parent) {
+                if let Err(error) = fs::create_dir_all(parent) {
                     panic!("Failed to create directory {}: {}", parent.display(), error);
                 }
             }
@@ -31,10 +31,8 @@ fn files(list: &[(&'static str, Option<&'static str>)]) {
             if let Err(error) = fs::write(&path, content) {
                 panic!("Failed to create file {}: {}", path.display(), error);
             }
-        } else {
-            if let Err(error) = fs::create_dir_all(&path) {
-                panic!("Failed to create directory {}: {}", path.display(), error);
-            }
+        } else if let Err(error) = fs::create_dir_all(&path) {
+            panic!("Failed to create directory {}: {}", path.display(), error);
         }
     }
 }


### PR DESCRIPTION
This allows the user to avoid allocating a path in order to open file handles to relative paths.

This is achieved by allowing the creation of a `Root` instance, which refers to a directory from which relative paths are opened.

For example:

```rust
use std::io::Write;

use anyhow::{Context, Result};

use relative_path::Root;

fn main() -> Result<()> {
    let root = Root::open(".")?;

    let mut cargo_toml = root
        .open_options()
        .write(true)
        .append(true)
        .open("test.txt")
        .context("Opening file")?;

    cargo_toml.write_all(b"Bye!\n")?;
    Ok(())
}
```