### PR TITLE
Add license files to the crate tarballs

### DIFF
--- a/relative-path-utils/LICENSE-APACHE
+++ b/relative-path-utils/LICENSE-APACHE
@@ -1,0 +1,1 @@
+../LICENSE-APACHE

--- a/relative-path-utils/LICENSE-MIT
+++ b/relative-path-utils/LICENSE-MIT
@@ -1,0 +1,1 @@
+../LICENSE-MIT

--- a/relative-path/LICENSE-APACHE
+++ b/relative-path/LICENSE-APACHE
@@ -1,0 +1,1 @@
+../LICENSE-APACHE

--- a/relative-path/LICENSE-MIT
+++ b/relative-path/LICENSE-MIT
@@ -1,0 +1,1 @@
+../LICENSE-MIT


### PR DESCRIPTION
It is common practice to include the license files in the distributed crate tarballs so that projects depending on the crates can also include the license text. This adds symlinks to the license files found at the root of the git repo for both the relative-path and relative-path-utils crates.