### PR TITLE
Fix doc typo for RelativePathBuf to Rc

### DIFF
--- a/relative-path/src/lib.rs
+++ b/relative-path/src/lib.rs
@@ -1926,7 +1926,7 @@ impl From<RelativePathBuf> for Arc<RelativePath> {
     }
 }
 
-/// Conversion from [`RelativePathBuf`] to [`Arc<RelativePath>`].
+/// Conversion from [`RelativePathBuf`] to [`Rc<RelativePath>`].
 ///
 /// # Examples
 ///


### PR DESCRIPTION
The docs say Arc where they should say Rc.