### PR TITLE
Allow building with no_std

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -22,14 +22,7 @@ jobs:
     steps:
     - uses: actions/checkout@v4
     - uses: dtolnay/rust-toolchain@1.66
-    - run: cargo build --workspace
     - run: cargo build --workspace --all-features
-    - run: cargo build --workspace --no-default-features
-    - run: cargo build -p relative-path --no-default-features
-    - run: cargo build -p relative-path --no-default-features --features=serde
-    - run: cargo build -p relative-path --no-default-features --features=alloc
-    - run: cargo build -p relative-path --no-default-features --features=serde,alloc
-    - run: cargo build -p relative-path-utils --no-default-features
 
   test:
     runs-on: ${{matrix.os}}
@@ -42,6 +35,17 @@ jobs:
     - uses: dtolnay/rust-toolchain@stable
     - run: cargo test --workspace --all-targets --all-features
     - run: cargo test --workspace --doc --all-features
+
+  build_features:
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        feature: ["", serde, alloc, "serde,alloc"]
+    steps:
+    - uses: actions/checkout@v4
+    - uses: dtolnay/rust-toolchain@1.66
+    - run: cargo build -p relative-path --no-default-features --features "${{matrix.feature}}"
 
   clippy:
     runs-on: ubuntu-latest

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -35,6 +35,7 @@ jobs:
     steps:
     - uses: actions/checkout@v4
     - uses: dtolnay/rust-toolchain@stable
+    - run: cargo test -p relative-path --no-default-features --tests
     - run: cargo test --workspace --all-targets --all-features
     - run: cargo test --workspace --doc --all-features
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -33,6 +33,7 @@ jobs:
     steps:
     - uses: actions/checkout@v4
     - uses: dtolnay/rust-toolchain@stable
+    - uses: Swatinem/rust-cache@v2
     - run: cargo test --workspace --all-targets --all-features
     - run: cargo test --workspace --doc --all-features
 
@@ -49,6 +50,7 @@ jobs:
     - uses: dtolnay/rust-toolchain@1.66
       with:
         components: clippy
+    - uses: Swatinem/rust-cache@v2
     - run: cargo check -p relative-path --no-default-features --features "${{matrix.feature}}"
     - run: cargo clippy -p relative-path --no-default-features --features "${{matrix.feature}}"
 
@@ -59,6 +61,7 @@ jobs:
     - uses: dtolnay/rust-toolchain@stable
       with:
         components: clippy
+    - uses: Swatinem/rust-cache@v2
     - run: cargo clippy --workspace --all-features --all-targets -- -D warnings
 
   rustfmt:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -36,16 +36,19 @@ jobs:
     - run: cargo test --workspace --all-targets --all-features
     - run: cargo test --workspace --doc --all-features
 
-  build_features:
+  build_feature:
     runs-on: ubuntu-latest
     strategy:
       fail-fast: false
       matrix:
-        feature: ["", serde, alloc, "serde,alloc"]
+        feature: ["", serde, alloc, "serde,alloc", std, "alloc,std"]
     steps:
     - uses: actions/checkout@v4
     - uses: dtolnay/rust-toolchain@1.66
-    - run: cargo build -p relative-path --no-default-features --features "${{matrix.feature}}"
+      with:
+        components: clippy
+    - run: cargo check -p relative-path --no-default-features --features "${{matrix.feature}}"
+    - run: cargo clippy -p relative-path --no-default-features --features "${{matrix.feature}}"
 
   clippy:
     runs-on: ubuntu-latest

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -25,6 +25,11 @@ jobs:
     - run: cargo build --workspace
     - run: cargo build --workspace --all-features
     - run: cargo build --workspace --no-default-features
+    - run: cargo build -p relative-path --no-default-features
+    - run: cargo build -p relative-path --no-default-features --features=serde
+    - run: cargo build -p relative-path --no-default-features --features=alloc
+    - run: cargo build -p relative-path --no-default-features --features=serde,alloc
+    - run: cargo build -p relative-path-utils --no-default-features
 
   test:
     runs-on: ${{matrix.os}}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -42,6 +42,8 @@ jobs:
       fail-fast: false
       matrix:
         feature: ["", serde, alloc, "serde,alloc", std, "alloc,std"]
+    env:
+      RUSTFLAGS: -D warnings
     steps:
     - uses: actions/checkout@v4
     - uses: dtolnay/rust-toolchain@1.66

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -40,7 +40,6 @@ jobs:
     steps:
     - uses: actions/checkout@v4
     - uses: dtolnay/rust-toolchain@stable
-    - run: cargo test -p relative-path --no-default-features --tests
     - run: cargo test --workspace --all-targets --all-features
     - run: cargo test --workspace --doc --all-features
 

--- a/relative-path-utils/Cargo.toml
+++ b/relative-path-utils/Cargo.toml
@@ -16,11 +16,8 @@ categories = ["filesystem"]
 [features]
 root = ["dep:windows-sys", "dep:libc", "dep:errno"]
 
-[dependencies.relative-path]
-path = "../relative-path"
-version = "1.9.2"
-default-features = false
-features = ["alloc"]
+[dependencies]
+relative-path = { path = "../relative-path", version = "1.9.2", default-features = false, features = ["alloc"] }
 
 [target.'cfg(windows)'.dependencies.windows-sys]
 version = "0.52.0"

--- a/relative-path-utils/Cargo.toml
+++ b/relative-path-utils/Cargo.toml
@@ -16,8 +16,11 @@ categories = ["filesystem"]
 [features]
 root = ["dep:windows-sys", "dep:libc", "dep:errno"]
 
-[dependencies]
-relative-path = { path = "../relative-path", version = "1.9.2" }
+[dependencies.relative-path]
+path = "../relative-path"
+version = "1.9.2"
+default-features = false
+features = ["alloc"]
 
 [target.'cfg(windows)'.dependencies.windows-sys]
 version = "0.52.0"

--- a/relative-path/Cargo.toml
+++ b/relative-path/Cargo.toml
@@ -14,13 +14,16 @@ keywords = ["path"]
 categories = ["filesystem"]
 
 [features]
-default = []
+default = ["std"]
+std = []
+serde = ["dep:serde" ]
 
 [dependencies]
-serde = { version = "1.0.160", optional = true }
+serde = { version = "1.0.160", optional = true, default-features = false, features = ["alloc"] }
 
 [dev-dependencies]
 anyhow = "1.0.76"
+foldhash = "0.1.5"
 serde = { version = "1.0.160", features = ["derive"] }
 
 [package.metadata.docs.rs]

--- a/relative-path/Cargo.toml
+++ b/relative-path/Cargo.toml
@@ -15,11 +15,12 @@ categories = ["filesystem"]
 
 [features]
 default = ["std"]
-std = []
+std = ["alloc"]
+alloc = ["serde?/alloc"]
 serde = ["dep:serde" ]
 
 [dependencies]
-serde = { version = "1.0.160", optional = true, default-features = false, features = ["alloc"] }
+serde = { version = "1.0.160", optional = true, default-features = false }
 
 [dev-dependencies]
 anyhow = "1.0.76"

--- a/relative-path/src/lib.rs
+++ b/relative-path/src/lib.rs
@@ -299,9 +299,6 @@ extern crate alloc;
 extern crate std;
 
 #[cfg(feature = "std")]
-use std::prelude::v1::*;
-
-#[cfg(feature = "std")]
 mod path_ext;
 
 #[cfg(test)]
@@ -309,6 +306,16 @@ mod tests;
 
 #[cfg(feature = "std")]
 pub use path_ext::{PathExt, RelativeToError};
+
+use core::cmp;
+use core::fmt;
+use core::hash::{Hash, Hasher};
+#[cfg(feature = "alloc")]
+use core::iter::FromIterator;
+use core::mem;
+#[cfg(feature = "alloc")]
+use core::ops;
+use core::str;
 
 #[cfg(feature = "alloc")]
 use alloc::borrow::{Borrow, Cow, ToOwned};
@@ -320,18 +327,11 @@ use alloc::rc::Rc;
 use alloc::string::String;
 #[cfg(feature = "alloc")]
 use alloc::sync::Arc;
-use core::cmp;
-use core::fmt;
-use core::hash::{Hash, Hasher};
-#[cfg(feature = "alloc")]
-use core::iter::FromIterator;
-use core::mem;
-#[cfg(feature = "alloc")]
-use core::ops;
-use core::str;
 
 #[cfg(feature = "std")]
-use std::{error, path};
+use std::error;
+#[cfg(feature = "std")]
+use std::path;
 
 const STEM_SEP: char = '.';
 const CURRENT_STR: &str = ".";
@@ -1921,7 +1921,7 @@ where
 /// let path: Box<RelativePath> = path.into();
 /// assert_eq!(&*path, "foo/bar");
 /// ```
-#[cfg(feature = "alloc")] 
+#[cfg(feature = "alloc")]
 impl From<RelativePathBuf> for Box<RelativePath> {
     #[inline]
     fn from(path: RelativePathBuf) -> Box<RelativePath> {

--- a/relative-path/src/lib.rs
+++ b/relative-path/src/lib.rs
@@ -288,7 +288,6 @@
 // https://github.com/rust-lang/rust
 // cb2a656cdfb6400ac0200c661267f91fabf237e2 src/libstd/path.rs
 
-#![allow(clippy::manual_let_else)]
 #![deny(missing_docs)]
 #![no_std]
 

--- a/relative-path/src/lib.rs
+++ b/relative-path/src/lib.rs
@@ -290,12 +290,15 @@
 
 #![allow(clippy::manual_let_else)]
 #![deny(missing_docs)]
-#![cfg_attr(not(feature = "std"), no_std)]
+#![no_std]
 
-#[cfg(not(feature = "std"))]
 extern crate alloc;
+
 #[cfg(feature = "std")]
-extern crate std as alloc;
+extern crate std;
+
+#[cfg(feature = "std")]
+use std::prelude::v1::*;
 
 #[cfg(feature = "std")]
 mod path_ext;
@@ -587,8 +590,8 @@ impl<'a> DoubleEndedIterator for Iter<'a> {
     }
 }
 
-#[cfg(feature = "std")]
 /// Error kind for [`FromPathError`].
+#[cfg(feature = "std")]
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 #[non_exhaustive]
 pub enum FromPathErrorKind {
@@ -600,9 +603,9 @@ pub enum FromPathErrorKind {
     BadSeparator,
 }
 
-#[cfg(feature = "std")]
 /// An error raised when attempting to convert a path using
 /// [`RelativePathBuf::from_path`].
+#[cfg(feature = "std")]
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct FromPathError {
     kind: FromPathErrorKind,
@@ -677,7 +680,6 @@ impl RelativePathBuf {
         }
     }
 
-    #[cfg(feature = "std")]
     /// Try to convert a [`Path`] to a [`RelativePathBuf`].
     ///
     /// [`Path`]: https://doc.rust-lang.org/std/path/struct.Path.html
@@ -701,6 +703,7 @@ impl RelativePathBuf {
     ///
     /// [`Prefix`]: std::path::Component::Prefix
     /// [`RootDir`]: std::path::Component::RootDir
+    #[cfg(feature = "std")]
     pub fn from_path<P: AsRef<path::Path>>(path: P) -> Result<RelativePathBuf, FromPathError> {
         use std::path::Component::{CurDir, Normal, ParentDir, Prefix, RootDir};
 
@@ -1043,7 +1046,6 @@ impl RelativePath {
         unsafe { &*(s.as_ref() as *const str as *const RelativePath) }
     }
 
-    #[cfg(feature = "std")]
     /// Try to convert a [`Path`] to a [`RelativePath`] without allocating a buffer.
     ///
     /// [`Path`]: std::path::Path
@@ -1075,6 +1077,7 @@ impl RelativePath {
     ///     assert_eq!(FromPathErrorKind::NonRelative, e.kind());
     /// }
     /// ```
+    #[cfg(feature = "std")]
     pub fn from_path<P: ?Sized + AsRef<path::Path>>(
         path: &P,
     ) -> Result<&RelativePath, FromPathError> {
@@ -1205,7 +1208,6 @@ impl RelativePath {
         RelativePathBuf::from(self.inner.to_owned())
     }
 
-    #[cfg(feature = "std")]
     /// Build an owned [`PathBuf`] relative to `base` for the current relative
     /// path.
     ///
@@ -1253,6 +1255,7 @@ impl RelativePath {
     ///
     /// [`PathBuf`]: std::path::PathBuf
     /// [`PathBuf::push`]: std::path::PathBuf::push
+    #[cfg(feature = "std")]
     pub fn to_path<P: AsRef<path::Path>>(&self, base: P) -> path::PathBuf {
         let mut p = base.as_ref().to_path_buf().into_os_string();
 
@@ -1267,7 +1270,6 @@ impl RelativePath {
         path::PathBuf::from(p)
     }
 
-    #[cfg(feature = "std")]
     /// Build an owned [`PathBuf`] relative to `base` for the current relative
     /// path.
     ///
@@ -1345,6 +1347,7 @@ impl RelativePath {
     ///
     /// [`PathBuf`]: std::path::PathBuf
     /// [`PathBuf::push`]: std::path::PathBuf::push
+    #[cfg(feature = "std")]
     pub fn to_logical_path<P: AsRef<path::Path>>(&self, base: P) -> path::PathBuf {
         use self::Component::{CurDir, Normal, ParentDir};
 

--- a/relative-path/src/lib.rs
+++ b/relative-path/src/lib.rs
@@ -1840,15 +1840,15 @@ impl RelativePath {
     }
 
     /// Check if path starts with a path separator.
-    #[allow(dead_code)]
     #[inline]
+    #[cfg(feature = "alloc")]
     fn starts_with_sep(&self) -> bool {
         self.inner.starts_with(SEP)
     }
 
     /// Check if path ends with a path separator.
-    #[allow(dead_code)]
     #[inline]
+    #[cfg(feature = "alloc")]
     fn ends_with_sep(&self) -> bool {
         self.inner.ends_with(SEP)
     }

--- a/relative-path/src/lib.rs
+++ b/relative-path/src/lib.rs
@@ -292,6 +292,7 @@
 #![deny(missing_docs)]
 #![no_std]
 
+#[cfg(feature = "alloc")]
 extern crate alloc;
 
 #[cfg(feature = "std")]
@@ -309,16 +310,23 @@ mod tests;
 #[cfg(feature = "std")]
 pub use path_ext::{PathExt, RelativeToError};
 
+#[cfg(feature = "alloc")]
 use alloc::borrow::{Borrow, Cow, ToOwned};
+#[cfg(feature = "alloc")]
 use alloc::boxed::Box;
+#[cfg(feature = "alloc")]
 use alloc::rc::Rc;
+#[cfg(feature = "alloc")]
 use alloc::string::String;
+#[cfg(feature = "alloc")]
 use alloc::sync::Arc;
 use core::cmp;
 use core::fmt;
 use core::hash::{Hash, Hasher};
+#[cfg(feature = "alloc")]
 use core::iter::FromIterator;
 use core::mem;
+#[cfg(feature = "alloc")]
 use core::ops;
 use core::str;
 
@@ -456,6 +464,7 @@ impl AsRef<RelativePath> for Component<'_> {
 ///
 /// This takes '.', and '..' into account. Where '.' doesn't change the stack, and '..' pops the
 /// last item or further adds parent components.
+#[cfg(feature = "alloc")]
 #[inline(always)]
 fn relative_traversal<'a, C>(buf: &mut RelativePathBuf, components: C)
 where
@@ -659,11 +668,13 @@ impl error::Error for FromPathError {}
 /// An owned, mutable relative path.
 ///
 /// This type provides methods to manipulate relative path objects.
+#[cfg(feature = "alloc")]
 #[derive(Clone)]
 pub struct RelativePathBuf {
     inner: String,
 }
 
+#[cfg(feature = "alloc")]
 impl RelativePathBuf {
     /// Create a new relative path buffer.
     #[must_use]
@@ -896,7 +907,7 @@ impl RelativePathBuf {
         self.inner
     }
 
-    /// Converts this `RelativePathBuf` into a [boxed][std::boxed::Box]
+    /// Converts this `RelativePathBuf` into a [boxed][alloc::boxed::Box]
     /// [`RelativePath`].
     #[must_use]
     pub fn into_boxed_relative_path(self) -> Box<RelativePath> {
@@ -905,12 +916,14 @@ impl RelativePathBuf {
     }
 }
 
+#[cfg(feature = "alloc")]
 impl Default for RelativePathBuf {
     fn default() -> Self {
         RelativePathBuf::new()
     }
 }
 
+#[cfg(feature = "alloc")]
 impl<'a> From<&'a RelativePath> for Cow<'a, RelativePath> {
     #[inline]
     fn from(s: &'a RelativePath) -> Cow<'a, RelativePath> {
@@ -918,6 +931,7 @@ impl<'a> From<&'a RelativePath> for Cow<'a, RelativePath> {
     }
 }
 
+#[cfg(feature = "alloc")]
 impl<'a> From<RelativePathBuf> for Cow<'a, RelativePath> {
     #[inline]
     fn from(s: RelativePathBuf) -> Cow<'a, RelativePath> {
@@ -925,12 +939,14 @@ impl<'a> From<RelativePathBuf> for Cow<'a, RelativePath> {
     }
 }
 
+#[cfg(feature = "alloc")]
 impl fmt::Debug for RelativePathBuf {
     fn fmt(&self, fmt: &mut fmt::Formatter) -> fmt::Result {
         write!(fmt, "{:?}", &self.inner)
     }
 }
 
+#[cfg(feature = "alloc")]
 impl AsRef<RelativePath> for RelativePathBuf {
     fn as_ref(&self) -> &RelativePath {
         RelativePath::new(&self.inner)
@@ -943,6 +959,7 @@ impl AsRef<str> for RelativePath {
     }
 }
 
+#[cfg(feature = "alloc")]
 impl Borrow<RelativePath> for RelativePathBuf {
     #[inline]
     fn borrow(&self) -> &RelativePath {
@@ -950,6 +967,7 @@ impl Borrow<RelativePath> for RelativePathBuf {
     }
 }
 
+#[cfg(feature = "alloc")]
 impl<'a, T: ?Sized + AsRef<str>> From<&'a T> for RelativePathBuf {
     fn from(path: &'a T) -> RelativePathBuf {
         RelativePathBuf {
@@ -958,18 +976,21 @@ impl<'a, T: ?Sized + AsRef<str>> From<&'a T> for RelativePathBuf {
     }
 }
 
+#[cfg(feature = "alloc")]
 impl From<String> for RelativePathBuf {
     fn from(path: String) -> RelativePathBuf {
         RelativePathBuf { inner: path }
     }
 }
 
+#[cfg(feature = "alloc")]
 impl From<RelativePathBuf> for String {
     fn from(path: RelativePathBuf) -> String {
         path.into_string()
     }
 }
 
+#[cfg(feature = "alloc")]
 impl ops::Deref for RelativePathBuf {
     type Target = RelativePath;
 
@@ -978,14 +999,17 @@ impl ops::Deref for RelativePathBuf {
     }
 }
 
+#[cfg(feature = "alloc")]
 impl cmp::PartialEq for RelativePathBuf {
     fn eq(&self, other: &RelativePathBuf) -> bool {
         self.components() == other.components()
     }
 }
 
+#[cfg(feature = "alloc")]
 impl cmp::Eq for RelativePathBuf {}
 
+#[cfg(feature = "alloc")]
 impl cmp::PartialOrd for RelativePathBuf {
     #[inline]
     fn partial_cmp(&self, other: &RelativePathBuf) -> Option<cmp::Ordering> {
@@ -993,6 +1017,7 @@ impl cmp::PartialOrd for RelativePathBuf {
     }
 }
 
+#[cfg(feature = "alloc")]
 impl cmp::Ord for RelativePathBuf {
     #[inline]
     fn cmp(&self, other: &RelativePathBuf) -> cmp::Ordering {
@@ -1000,12 +1025,14 @@ impl cmp::Ord for RelativePathBuf {
     }
 }
 
+#[cfg(feature = "alloc")]
 impl Hash for RelativePathBuf {
     fn hash<H: Hasher>(&self, h: &mut H) {
         self.as_relative_path().hash(h);
     }
 }
 
+#[cfg(feature = "alloc")]
 impl<P> Extend<P> for RelativePathBuf
 where
     P: AsRef<RelativePath>,
@@ -1016,6 +1043,7 @@ where
     }
 }
 
+#[cfg(feature = "alloc")]
 impl<P> FromIterator<P> for RelativePathBuf
 where
     P: AsRef<RelativePath>,
@@ -1121,7 +1149,7 @@ impl RelativePath {
         &self.inner
     }
 
-    /// Returns an object that implements [`Display`][std::fmt::Display].
+    /// Returns an object that implements [`Display`][core::fmt::Display].
     ///
     /// # Examples
     ///
@@ -1148,6 +1176,7 @@ impl RelativePath {
     /// let path = RelativePath::new("foo/bar");
     /// assert_eq!("foo/bar/baz", path.join("baz"));
     /// ```
+    #[cfg(feature = "alloc")]
     pub fn join<P>(&self, path: P) -> RelativePathBuf
     where
         P: AsRef<RelativePath>,
@@ -1203,6 +1232,7 @@ impl RelativePath {
     }
 
     /// Convert to an owned [`RelativePathBuf`].
+    #[cfg(feature = "alloc")]
     #[must_use]
     pub fn to_relative_path_buf(&self) -> RelativePathBuf {
         RelativePathBuf::from(self.inner.to_owned())
@@ -1555,6 +1585,7 @@ impl RelativePath {
     /// let path = RelativePath::new("tmp");
     /// assert_eq!(path.with_file_name("var"), RelativePathBuf::from("var"));
     /// ```
+    #[cfg(feature = "alloc")]
     pub fn with_file_name<S: AsRef<str>>(&self, file_name: S) -> RelativePathBuf {
         let mut buf = self.to_relative_path_buf();
         buf.set_file_name(file_name);
@@ -1624,6 +1655,7 @@ impl RelativePath {
     /// let path = RelativePath::new("foo.rs");
     /// assert_eq!(path.with_extension("txt"), RelativePathBuf::from("foo.txt"));
     /// ```
+    #[cfg(feature = "alloc")]
     pub fn with_extension<S: AsRef<str>>(&self, extension: S) -> RelativePathBuf {
         let mut buf = self.to_relative_path_buf();
         buf.set_extension(extension);
@@ -1648,6 +1680,7 @@ impl RelativePath {
     ///     RelativePath::new("../foo/bar").join_normalized("../baz.txt").as_relative_path()
     /// );
     /// ```
+    #[cfg(feature = "alloc")]
     pub fn join_normalized<P>(&self, path: P) -> RelativePathBuf
     where
         P: AsRef<RelativePath>,
@@ -1689,6 +1722,7 @@ impl RelativePath {
     ///     RelativePath::new(".").normalize()
     /// );
     /// ```
+    #[cfg(feature = "alloc")]
     #[must_use]
     pub fn normalize(&self) -> RelativePathBuf {
         let mut buf = RelativePathBuf::with_capacity(self.inner.len());
@@ -1758,6 +1792,7 @@ impl RelativePath {
     /// assert_eq!("../../../../../arch/foo.h", a.relative(b));
     /// assert_eq!("", b.relative(a));
     /// ```
+    #[cfg(feature = "alloc")]
     pub fn relative<P>(&self, path: P) -> RelativePathBuf
     where
         P: AsRef<RelativePath>,
@@ -1805,12 +1840,14 @@ impl RelativePath {
     }
 
     /// Check if path starts with a path separator.
+    #[allow(dead_code)]
     #[inline]
     fn starts_with_sep(&self) -> bool {
         self.inner.starts_with(SEP)
     }
 
     /// Check if path ends with a path separator.
+    #[allow(dead_code)]
     #[inline]
     fn ends_with_sep(&self) -> bool {
         self.inner.ends_with(SEP)
@@ -1837,6 +1874,7 @@ impl<'a> IntoIterator for &'a RelativePath {
 /// let path: Box<RelativePath> = Box::<str>::from("foo/bar").into();
 /// assert_eq!(&*path, "foo/bar");
 /// ```
+#[cfg(feature = "alloc")]
 impl From<Box<str>> for Box<RelativePath> {
     #[inline]
     fn from(boxed: Box<str>) -> Box<RelativePath> {
@@ -1860,6 +1898,7 @@ impl From<Box<str>> for Box<RelativePath> {
 /// let path: Box<RelativePath> = RelativePath::new("foo/bar").into();
 /// assert_eq!(&*path, "foo/bar");
 /// ```
+#[cfg(feature = "alloc")]
 impl<T> From<&T> for Box<RelativePath>
 where
     T: ?Sized + AsRef<str>,
@@ -1882,6 +1921,7 @@ where
 /// let path: Box<RelativePath> = path.into();
 /// assert_eq!(&*path, "foo/bar");
 /// ```
+#[cfg(feature = "alloc")] 
 impl From<RelativePathBuf> for Box<RelativePath> {
     #[inline]
     fn from(path: RelativePathBuf) -> Box<RelativePath> {
@@ -1902,6 +1942,7 @@ impl From<RelativePathBuf> for Box<RelativePath> {
 /// let path2 = path.clone();
 /// assert_eq!(&*path, &*path2);
 /// ```
+#[cfg(feature = "alloc")]
 impl Clone for Box<RelativePath> {
     #[inline]
     fn clone(&self) -> Self {
@@ -1920,6 +1961,7 @@ impl Clone for Box<RelativePath> {
 /// let path: Arc<RelativePath> = RelativePath::new("foo/bar").into();
 /// assert_eq!(&*path, "foo/bar");
 /// ```
+#[cfg(feature = "alloc")]
 impl From<&RelativePath> for Arc<RelativePath> {
     #[inline]
     fn from(path: &RelativePath) -> Arc<RelativePath> {
@@ -1941,6 +1983,7 @@ impl From<&RelativePath> for Arc<RelativePath> {
 /// let path: Arc<RelativePath> = path.into();
 /// assert_eq!(&*path, "foo/bar");
 /// ```
+#[cfg(feature = "alloc")]
 impl From<RelativePathBuf> for Arc<RelativePath> {
     #[inline]
     fn from(path: RelativePathBuf) -> Arc<RelativePath> {
@@ -1961,6 +2004,7 @@ impl From<RelativePathBuf> for Arc<RelativePath> {
 /// let path: Rc<RelativePath> = RelativePath::new("foo/bar").into();
 /// assert_eq!(&*path, "foo/bar");
 /// ```
+#[cfg(feature = "alloc")]
 impl From<&RelativePath> for Rc<RelativePath> {
     #[inline]
     fn from(path: &RelativePath) -> Rc<RelativePath> {
@@ -1982,6 +2026,7 @@ impl From<&RelativePath> for Rc<RelativePath> {
 /// let path: Rc<RelativePath> = path.into();
 /// assert_eq!(&*path, "foo/bar");
 /// ```
+#[cfg(feature = "alloc")]
 impl From<RelativePathBuf> for Rc<RelativePath> {
     #[inline]
     fn from(path: RelativePathBuf) -> Rc<RelativePath> {
@@ -2001,6 +2046,7 @@ impl From<RelativePathBuf> for Rc<RelativePath> {
 /// let path = RelativePath::new("foo/bar").to_owned();
 /// assert_eq!(path, "foo/bar");
 /// ```
+#[cfg(feature = "alloc")]
 impl ToOwned for RelativePath {
     type Owned = RelativePathBuf;
 
@@ -2028,6 +2074,7 @@ impl fmt::Debug for RelativePath {
 /// let string: &str = path.as_ref();
 /// assert_eq!(string, "foo/bar");
 /// ```
+#[cfg(feature = "alloc")]
 impl AsRef<str> for RelativePathBuf {
     #[inline]
     fn as_ref(&self) -> &str {
@@ -2046,6 +2093,7 @@ impl AsRef<str> for RelativePathBuf {
 /// let path: &RelativePath = path.as_ref();
 /// assert_eq!(path, "foo/bar");
 /// ```
+#[cfg(feature = "alloc")]
 impl AsRef<RelativePath> for String {
     #[inline]
     fn as_ref(&self) -> &RelativePath {
@@ -2118,6 +2166,7 @@ impl fmt::Display for RelativePath {
     }
 }
 
+#[cfg(feature = "alloc")]
 impl fmt::Display for RelativePathBuf {
     #[inline]
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
@@ -2132,7 +2181,7 @@ impl fmt::Display for RelativePathBuf {
 /// preserved to simplify the transition between [`Path`] and [`RelativePath`].
 ///
 /// [`Path`]: std::path::Path
-/// [`Display`]: std::fmt::Display
+/// [`Display`]: core::fmt::Display
 pub struct Display<'a> {
     path: &'a RelativePath,
 }
@@ -2162,6 +2211,7 @@ impl fmt::Display for Display<'_> {
 ///     path: RelativePathBuf,
 /// }
 /// ```
+#[cfg(feature = "alloc")]
 #[cfg(feature = "serde")]
 impl serde::ser::Serialize for RelativePathBuf {
     #[inline]
@@ -2184,6 +2234,7 @@ impl serde::ser::Serialize for RelativePathBuf {
 ///     path: RelativePathBuf,
 /// }
 /// ```
+#[cfg(feature = "alloc")]
 #[cfg(feature = "serde")]
 impl<'de> serde::de::Deserialize<'de> for RelativePathBuf {
     fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
@@ -2200,6 +2251,7 @@ impl<'de> serde::de::Deserialize<'de> for RelativePathBuf {
                 formatter.write_str("a relative path")
             }
 
+            #[cfg(feature = "alloc")]
             #[inline]
             fn visit_string<E>(self, input: String) -> Result<Self::Value, E>
             where
@@ -2232,7 +2284,7 @@ impl<'de> serde::de::Deserialize<'de> for RelativePathBuf {
 ///     path: Box<RelativePath>,
 /// }
 /// ```
-#[cfg(feature = "serde")]
+#[cfg(all(feature = "serde", feature = "alloc"))]
 impl<'de> serde::de::Deserialize<'de> for Box<RelativePath> {
     fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
     where
@@ -2248,6 +2300,7 @@ impl<'de> serde::de::Deserialize<'de> for Box<RelativePath> {
                 formatter.write_str("a relative path")
             }
 
+            #[cfg(feature = "alloc")]
             #[inline]
             fn visit_string<E>(self, input: String) -> Result<Self::Value, E>
             where
@@ -2343,6 +2396,7 @@ impl serde::ser::Serialize for RelativePath {
     }
 }
 
+#[cfg(feature = "alloc")]
 macro_rules! impl_cmp {
     ($lhs:ty, $rhs:ty) => {
         impl<'a, 'b> PartialEq<$rhs> for $lhs {
@@ -2375,10 +2429,15 @@ macro_rules! impl_cmp {
     };
 }
 
+#[cfg(feature = "alloc")]
 impl_cmp!(RelativePathBuf, RelativePath);
+#[cfg(feature = "alloc")]
 impl_cmp!(RelativePathBuf, &'a RelativePath);
+#[cfg(feature = "alloc")]
 impl_cmp!(Cow<'a, RelativePath>, RelativePath);
+#[cfg(feature = "alloc")]
 impl_cmp!(Cow<'a, RelativePath>, &'b RelativePath);
+#[cfg(feature = "alloc")]
 impl_cmp!(Cow<'a, RelativePath>, RelativePathBuf);
 
 macro_rules! impl_cmp_str {
@@ -2413,11 +2472,16 @@ macro_rules! impl_cmp_str {
     };
 }
 
+#[cfg(feature = "alloc")]
 impl_cmp_str!(RelativePathBuf, str);
+#[cfg(feature = "alloc")]
 impl_cmp_str!(RelativePathBuf, &'a str);
+#[cfg(feature = "alloc")]
 impl_cmp_str!(RelativePathBuf, String);
 impl_cmp_str!(RelativePath, str);
 impl_cmp_str!(RelativePath, &'a str);
+#[cfg(feature = "alloc")]
 impl_cmp_str!(RelativePath, String);
 impl_cmp_str!(&'a RelativePath, str);
+#[cfg(feature = "alloc")]
 impl_cmp_str!(&'a RelativePath, String);

--- a/relative-path/src/lib.rs
+++ b/relative-path/src/lib.rs
@@ -290,26 +290,37 @@
 
 #![allow(clippy::manual_let_else)]
 #![deny(missing_docs)]
+#![cfg_attr(not(feature = "std"), no_std)]
 
+#[cfg(not(feature = "std"))]
+extern crate alloc;
+#[cfg(feature = "std")]
+extern crate std as alloc;
+
+#[cfg(feature = "std")]
 mod path_ext;
 
 #[cfg(test)]
 mod tests;
 
+#[cfg(feature = "std")]
 pub use path_ext::{PathExt, RelativeToError};
 
-use std::borrow::{Borrow, Cow};
-use std::cmp;
-use std::error;
-use std::fmt;
-use std::hash::{Hash, Hasher};
-use std::iter::FromIterator;
-use std::mem;
-use std::ops;
-use std::path;
-use std::rc::Rc;
-use std::str;
-use std::sync::Arc;
+use alloc::borrow::{Borrow, Cow, ToOwned};
+use alloc::boxed::Box;
+use alloc::rc::Rc;
+use alloc::string::String;
+use alloc::sync::Arc;
+use core::cmp;
+use core::fmt;
+use core::hash::{Hash, Hasher};
+use core::iter::FromIterator;
+use core::mem;
+use core::ops;
+use core::str;
+
+#[cfg(feature = "std")]
+use std::{error, path};
 
 const STEM_SEP: char = '.';
 const CURRENT_STR: &str = ".";
@@ -576,6 +587,7 @@ impl<'a> DoubleEndedIterator for Iter<'a> {
     }
 }
 
+#[cfg(feature = "std")]
 /// Error kind for [`FromPathError`].
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 #[non_exhaustive]
@@ -588,6 +600,7 @@ pub enum FromPathErrorKind {
     BadSeparator,
 }
 
+#[cfg(feature = "std")]
 /// An error raised when attempting to convert a path using
 /// [`RelativePathBuf::from_path`].
 #[derive(Debug, Clone, PartialEq, Eq)]
@@ -595,6 +608,7 @@ pub struct FromPathError {
     kind: FromPathErrorKind,
 }
 
+#[cfg(feature = "std")]
 impl FromPathError {
     /// Gets the underlying [`FromPathErrorKind`] that provides more details on
     /// what went wrong.
@@ -616,12 +630,14 @@ impl FromPathError {
     }
 }
 
+#[cfg(feature = "std")]
 impl From<FromPathErrorKind> for FromPathError {
     fn from(value: FromPathErrorKind) -> Self {
         Self { kind: value }
     }
 }
 
+#[cfg(feature = "std")]
 impl fmt::Display for FromPathError {
     fn fmt(&self, fmt: &mut fmt::Formatter) -> fmt::Result {
         match self.kind {
@@ -634,6 +650,7 @@ impl fmt::Display for FromPathError {
     }
 }
 
+#[cfg(feature = "std")]
 impl error::Error for FromPathError {}
 
 /// An owned, mutable relative path.
@@ -660,6 +677,7 @@ impl RelativePathBuf {
         }
     }
 
+    #[cfg(feature = "std")]
     /// Try to convert a [`Path`] to a [`RelativePathBuf`].
     ///
     /// [`Path`]: https://doc.rust-lang.org/std/path/struct.Path.html
@@ -1025,6 +1043,7 @@ impl RelativePath {
         unsafe { &*(s.as_ref() as *const str as *const RelativePath) }
     }
 
+    #[cfg(feature = "std")]
     /// Try to convert a [`Path`] to a [`RelativePath`] without allocating a buffer.
     ///
     /// [`Path`]: std::path::Path
@@ -1186,6 +1205,7 @@ impl RelativePath {
         RelativePathBuf::from(self.inner.to_owned())
     }
 
+    #[cfg(feature = "std")]
     /// Build an owned [`PathBuf`] relative to `base` for the current relative
     /// path.
     ///
@@ -1247,6 +1267,7 @@ impl RelativePath {
         path::PathBuf::from(p)
     }
 
+    #[cfg(feature = "std")]
     /// Build an owned [`PathBuf`] relative to `base` for the current relative
     /// path.
     ///

--- a/relative-path/src/path_ext.rs
+++ b/relative-path/src/path_ext.rs
@@ -16,6 +16,7 @@
 use core::error;
 use core::fmt;
 use std::path::{Path, PathBuf};
+use std::prelude::v1::*;
 
 use crate::{Component, RelativePathBuf};
 

--- a/relative-path/src/path_ext.rs
+++ b/relative-path/src/path_ext.rs
@@ -13,8 +13,8 @@
 // https://github.com/Manishearth/pathdiff/blob/master/src/lib.rs
 // https://github.com/rust-lang/rust/blob/e1d0de82cc40b666b88d4a6d2c9dcbc81d7ed27f/src/librustc_back/rpath.rs#L116-L158
 
-use std::error;
-use std::fmt;
+use core::error;
+use core::fmt;
 use std::path::{Path, PathBuf};
 
 use crate::{Component, RelativePathBuf};

--- a/relative-path/src/path_ext.rs
+++ b/relative-path/src/path_ext.rs
@@ -13,8 +13,8 @@
 // https://github.com/Manishearth/pathdiff/blob/master/src/lib.rs
 // https://github.com/rust-lang/rust/blob/e1d0de82cc40b666b88d4a6d2c9dcbc81d7ed27f/src/librustc_back/rpath.rs#L116-L158
 
-use core::error;
 use core::fmt;
+use std::error;
 use std::path::{Path, PathBuf};
 use std::prelude::v1::*;
 

--- a/relative-path/src/tests.rs
+++ b/relative-path/src/tests.rs
@@ -3,6 +3,7 @@
 use super::*;
 
 use std::path::Path;
+use std::prelude::v1::*;
 use std::rc::Rc;
 use std::sync::Arc;
 

--- a/relative-path/src/tests.rs
+++ b/relative-path/src/tests.rs
@@ -6,6 +6,7 @@ use std::path::Path;
 use std::prelude::v1::*;
 use std::rc::Rc;
 use std::sync::Arc;
+use std::{format, vec};
 
 macro_rules! t(
     ($path:expr, iter: $iter:expr) => (

--- a/relative-path/src/tests.rs
+++ b/relative-path/src/tests.rs
@@ -2,11 +2,13 @@
 
 use super::*;
 
+use std::format;
 use std::path::Path;
-use std::prelude::v1::*;
 use std::rc::Rc;
+use std::string::ToString;
 use std::sync::Arc;
-use std::{format, vec};
+use std::vec;
+use std::vec::Vec;
 
 macro_rules! t(
     ($path:expr, iter: $iter:expr) => (


### PR DESCRIPTION
This PR adds a default `std` feature.
Disabling this feature removes the `std::path::Path` interop, and adds support for `no_std`.

Fixes #63.