### PR TITLE
Implement camino conversions for RelativePath

### DIFF
--- a/relative-path/Cargo.toml
+++ b/relative-path/Cargo.toml
@@ -21,9 +21,11 @@ default = ["std", "alloc"]
 alloc = ["serde?/alloc"]
 std = []
 serde = ["dep:serde" ]
+camino = ["dep:camino"]
 
 [dependencies]
 serde = { version = "1.0.160", optional = true, default-features = false }
+camino = { version = "1", optional = true }
 
 [dev-dependencies]
 anyhow = "1.0.76"

--- a/relative-path/src/lib.rs
+++ b/relative-path/src/lib.rs
@@ -1752,6 +1752,14 @@ impl AsRef<RelativePath> for RelativePath {
     }
 }
 
+#[cfg(feature = "camino")]
+impl AsRef<camino::Utf8Path> for RelativePath {
+    #[inline]
+    fn as_ref(&self) -> &camino::Utf8Path {
+        camino::Utf8Path::new(self.as_str())
+    }
+}
+
 impl cmp::PartialEq for RelativePath {
     #[inline]
     fn eq(&self, other: &RelativePath) -> bool {

--- a/relative-path/src/lib.rs
+++ b/relative-path/src/lib.rs
@@ -1760,6 +1760,14 @@ impl AsRef<camino::Utf8Path> for RelativePath {
     }
 }
 
+#[cfg(feature = "camino")]
+impl<'a> From<&'a RelativePath> for &'a camino::Utf8Path {
+    #[inline]
+    fn from(x: &'a RelativePath) -> &'a camino::Utf8Path {
+        x.as_ref()
+    }
+}
+
 impl cmp::PartialEq for RelativePath {
     #[inline]
     fn eq(&self, other: &RelativePath) -> bool {

--- a/relative-path/src/relative_path_buf.rs
+++ b/relative-path/src/relative_path_buf.rs
@@ -338,6 +338,14 @@ impl<'a> From<RelativePathBuf> for Cow<'a, RelativePath> {
     }
 }
 
+#[cfg(feature = "camino")]
+impl From<RelativePathBuf> for camino::Utf8PathBuf {
+    #[inline]
+    fn from(s: RelativePathBuf) -> camino::Utf8PathBuf {
+        String::from(s).into()
+    }
+}
+
 impl fmt::Debug for RelativePathBuf {
     #[inline]
     fn fmt(&self, fmt: &mut fmt::Formatter) -> fmt::Result {


### PR DESCRIPTION
This is an uncontroversial subset of the functionality in #70 .

Adds an optional "camino" feature.